### PR TITLE
feat: add APAC region support (AU/NZ/JP/KR/SG/TH...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,19 +499,31 @@ Geely runs a separate backend per area, each with its **own app credentials**:
 |---|---|---|
 | **EU / International** | `api.ecloudeu.com` | ✅ supported |
 | **NA** (US, CA, MX - and Brazilian accounts, which resolve here) | `api.ecloudus.com` | ✅ supported |
-| **APAC** (AU, NZ, JP, KR, SG, TH…) | `api.ecloudkr.com` | ❌ credentials not public |
+| **APAC** (AU, NZ, JP, KR, SG, TH…) | `api.ecloudkr.com` | ✅ supported |
 | **SA** | `tsp-geely-api-sa.xcloudsvc.com` | ❌ credentials not public |
 
 The area belongs to the **vehicle**, not to the country you pick at setup - the
 two can differ - so it is read from the login response
-(`tspInfo[].serviceRegion`, falling back to `edgeInfo.code`) and stored on the
+(`tspInfo[].serviceRegion`, falling back to `edgeInfo.code`, then the vehicle
+record's top-level `serviceRegion`, then `saleMarket`/`tcamMarket` - APAC
+accounts have `"AP"` - and finally a safe EU default) and stored on the
 config entry. Login, the email code and the vehicle list are not regional in
-practice; only certificate provisioning and control commands are.
+practice; only certificate provisioning, the session exchange and control
+commands are.
+
+APAC specifics: the session exchange runs on the **public** host
+`api.ecloudkr.com` at `/auth-center/account/session` (not on the mTLS control
+host), requires `receiverId` (the login email) in the body, an
+`Accept: application/json; charset=utf-8` header and **uppercase**
+`X-SIGNATURE`/`X-TIMESTAMP` signature headers, and the access code must be
+minted by the APAC regional host (`m-lcmsam-kr.geely.com`) - codes from the
+EU/global hosts make the APAC session service crash with `8500`. See
+`docs/APAC-SUPPORT.md` for the full write-up.
 
 A car in an area whose credentials are unknown stops the setup with a clear
 message naming the area, rather than being signed against the European backend
 and failing with the opaque `1501 geelyos verify error` that the upstream
-project reports. Adding APAC or SA needs that area's app id and secret.
+project reports. Adding SA needs that area's app id and secret.
 
 ---
 

--- a/custom_components/geely_connect/__init__.py
+++ b/custom_components/geely_connect/__init__.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_DEVICE_IDFA,
     CONF_DEVICE_IDFV,
+    CONF_EMAIL,
     CONF_FULL_EXPOSURE,
     CONF_KEY_PATH,
     CONF_POLL_MODE,
@@ -304,6 +305,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         cert_path=d[CONF_CERT_PATH],
         key_path=d[CONF_KEY_PATH],
         control_host=backend["control_host"],
+        email=d.get(CONF_EMAIL),
     )
 
     _SUCCESS_CODES = {1000, "1000", 10000000, "10000000", None}

--- a/custom_components/geely_connect/api.py
+++ b/custom_components/geely_connect/api.py
@@ -307,6 +307,7 @@ _TLS_LEGACY_RENEG = 0x4   # OP_LEGACY_SERVER_CONNECT - old handshake mode only
 _PRIVATE_PKI_HOSTS: frozenset = frozenset({
     "apis.ecloudeu.com",
     "apis.ecloudus.com",
+    "apis.ecloudkr.com",
 })
 
 # SubjectPublicKeyInfo SHA-256 pins (base64) for those hosts. Captured
@@ -317,6 +318,11 @@ _PRIVATE_PKI_HOSTS: frozenset = frozenset({
 _BUNDLED_TLS_PINS: dict[str, tuple[str, ...]] = {
     "apis.ecloudeu.com": ("Hm0olBoClunXgMp4wFvdrr8SC5iSt+LX6iyB4N828C8=",),
     "apis.ecloudus.com": ("yTrWM8YjYq6ivb6HP1usQiBdgZYGiCwR6yuQYOm2KVs=",),
+    # Captured 2026-08-03 from all three published A records
+    # (3.34.148.140, 3.36.84.152, 3.39.68.203) - same SPKI on all, cross-checked
+    # against the strict-failure chain (Geely Trust Center / EU-CA leaf,
+    # subject CN=apis.ecloudkr.com, valid 2022-2032).
+    "apis.ecloudkr.com": ("XFUV7VhyECWtALG5wEQoAj3FSWtsf3IpBq6l2mBgVWA=",),
 }
 
 # OpenSSL verify codes that mean "the chain is fine, we just don't have this
@@ -618,6 +624,7 @@ class GeelyApi:
         cert_path: str,
         key_path: str,
         control_host: str = "apis.ecloudeu.com",
+        email: str | None = None,
     ) -> None:
         self.app_id = app_id
         self.app_secret = app_secret
@@ -632,6 +639,9 @@ class GeelyApi:
         self.key_path = key_path
         # Regional control endpoint; see const.REGIONS.
         self.control_host = control_host
+        # Login email: the APAC session exchange authenticates with it as
+        # receiverId in the request body (the EU exchange does not).
+        self.email = email
         # Server-key pin store lives next to the mTLS material for this VIN.
         self.pin_path = os.path.join(os.path.dirname(cert_path), "server_pins.json") \
             if cert_path else None
@@ -723,11 +733,16 @@ class GeelyApi:
 
     # ---- high-level operations ----
 
-    def _get_access_code(self) -> str:
-        """1-time accessCode from cidpsso (used to fetch apis JWT)."""
+    def _get_access_code(self, host: str = "m-lcmsam-eu.geely.com") -> str:
+        """1-time accessCode from cidpsso (used to fetch apis JWT).
+
+        The code must be minted by the SAME regional backend that will later
+        exchange it: the APAC session service only recognises codes issued by
+        m-lcmsam-kr.geely.com (EU-minted codes make it crash with 8500).
+        """
         body = json.dumps({"state": str(uuid.uuid4())}).encode()
         resp_bytes = _raw_https(
-            "m-lcmsam-eu.geely.com", "POST",
+            host, "POST",
             "/cidpsso/oauth2/v1/getCode",
             {
                 "token": self.cidpsso_token,
@@ -743,8 +758,81 @@ class GeelyApi:
             raise RuntimeError(f"getCode failed: {redact(j)}")
         return j["data"]["accessCode"]
 
+    # ---- APAC session exchange (api.ecloudkr.com, NO mTLS) ----
+    #
+    # The EU flow exchanges the accessCode on the mTLS control host
+    # (apis.ecloudeu.com /auth/account/session/secure). The APAC backend
+    # instead runs the exchange on the PUBLIC host api.ecloudkr.com at
+    # /auth-center/account/session with a receiverId body field, a
+    # charset=utf-8 Accept, and UPPERCASE X-SIGNATURE/X-TIMESTAMP headers
+    # (the lowercase variants are rejected with 1445 by the APAC gateway).
+    # Verified end-to-end 2026-08-03: getCode via m-lcmsam-kr -> JWT
+    # (HS256, uid, appId=GEELYE245) -> vehicle_status via mTLS = code 1000.
+
+    def _apac_session_exchange(self) -> dict:
+        """Exchange a KR-minted accessCode for the apis.ecloudkr.com JWT."""
+        if not self.email:
+            raise GeelyAuthError(
+                "APAC session exchange needs the login email (receiverId) "
+                "but the config entry has none - re-add the integration."
+            )
+        ac = self._get_access_code(host="m-lcmsam-kr.geely.com")
+        body = json.dumps({
+            "identityType": "geelyos",
+            "authCode": ac,
+            "receiverId": self.email,
+        }, separators=(",", ":")).encode()
+
+        host = "api.ecloudkr.com"
+        path = "/auth-center/account/session"
+        nonce = _make_nonce()
+        ts_ms = int(time.time() * 1000)
+        # Sign string uses the charset=utf-8 Accept; headers are UPPERCASE.
+        ss = _build_sign_string(
+            method="POST", path=path, query="",
+            accept="application/json; charset=utf-8",
+            nonce=nonce, sig_version="1.0", timestamp_ms=ts_ms, body=body,
+        )
+        sig = base64.b64encode(
+            hmac.new(self.app_secret.encode(), ss.encode(), hashlib.sha1).digest()
+        ).decode()
+        headers = {
+            "Accept": "application/json; charset=utf-8",
+            "X-APP-ID": self.app_id,
+            "X-CLIENT-TYPE": "2",
+            "X-ENV-TYPE": "production",
+            "X-OPERATOR-CODE": "GEELY",
+            "X-VIN-ID": self.vin,
+            "urlname": "user-api",
+            "Authorization": self.cidpsso_token,
+            "Content-Type": "application/json; charset=utf-8",
+            "X-api-signature-version": "1.0",
+            "X-api-signature-nonce": nonce,
+            "X-TIMESTAMP": str(ts_ms),
+            "X-SIGNATURE": sig,
+            "user-agent": "okhttp/4.11.0",
+        }
+        resp_bytes = _raw_https(host, "POST", path, headers, body,
+                                pin_path=self.pin_path, timeout=15)
+        j = json.loads(resp_bytes)
+        # APAC success envelope: {"resultCode": "0", "resultMessage":
+        # "Success", "accessToken": ..., "userId": ..., "expiresIn": 7200}
+        if str(j.get("resultCode")) != "0":
+            raise GeelyAuthError(f"APAC session exchange failed: {redact(j)}")
+        return j
+
     def refresh_jwt(self) -> dict:
-        """Exchange a cidpsso accessCode for an apis.ecloudeu.com JWT."""
+        """Exchange a cidpsso accessCode for an apis.ecloudeu.com JWT.
+
+        APAC uses a different exchange (public host, receiverId body); see
+        _apac_session_exchange.
+        """
+        if self.control_host == "apis.ecloudkr.com":
+            d = self._apac_session_exchange()
+            self._jwt = d["accessToken"]
+            self._jwt_uid = d.get("userId") or self.user_id
+            self._jwt_exp = int(time.time()) + int(d.get("expiresIn", 7200))
+            return d
         ac = self._get_access_code()
         body = json.dumps({"authCode": ac}).encode()
         status, resp = self._mtls_send(

--- a/custom_components/geely_connect/config_flow.py
+++ b/custom_components/geely_connect/config_flow.py
@@ -325,6 +325,13 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # record, not from the country the user picked: the two can differ, and
         # signing against the wrong one is what produces the opaque 1501
         # "geelyos verify error".
+        _LOGGER.error("vehicle region debug: tspInfo=%s edgeInfo=%s "
+                      "serviceRegion=%s saleMarket=%s dcCode=%s "
+                      "deliveryCountryCode=%s tcamMarket=%s",
+                      vehicle.get("tspInfo"), vehicle.get("edgeInfo"),
+                      vehicle.get("serviceRegion"), vehicle.get("saleMarket"),
+                      vehicle.get("dcCode"), vehicle.get("deliveryCountryCode"),
+                      vehicle.get("tcamMarket"))
         region = resolve_vehicle_region(vehicle) or DEFAULT_REGION
         if region in UNSUPPORTED_REGIONS:
             _LOGGER.error(
@@ -334,8 +341,8 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             return self.async_abort(reason="wrong_region")
         backend = region_config(region)
-        _LOGGER.debug("provisioning against the %s backend (%s)",
-                      region, backend["cert_host"])
+        _LOGGER.error("provisioning against the %s backend (%s) - detected "
+                      "vehicle region code %r", region, backend["cert_host"], region)
 
         device_id = hashlib.md5(f"ha:{self._user_id}:{vin}".encode()).hexdigest()
         cert_path, key_path = _storage_paths(self.hass, vin)

--- a/custom_components/geely_connect/const.py
+++ b/custom_components/geely_connect/const.py
@@ -40,6 +40,12 @@ REGIONS: dict[str, dict[str, str]] = {
         "cert_host":    "api.ecloudus.com",
         "control_host": "apis.ecloudus.com",
     },
+    "APAC": {
+        "app_id":       "GEELYE245",
+        "app_secret":   "5b2e7f2f569e4173a9aea65e0c9133e3",
+        "cert_host":    "api.ecloudkr.com",
+        "control_host": "apis.ecloudkr.com",
+    },
 }
 
 # Areas whose hosts are known but whose app credentials have never been
@@ -47,7 +53,6 @@ REGIONS: dict[str, dict[str, str]] = {
 # message instead of being silently signed against the European backend, which
 # only produces the confusing "geelyos verify error".
 UNSUPPORTED_REGIONS: dict[str, str] = {
-    "APAC": "api.ecloudkr.com",
     "SA":   "tsp-geely-api-sa.xcloudsvc.com",
 }
 
@@ -170,6 +175,18 @@ SUPPORTED_COUNTRIES: dict[str, str] = {
     "CA": "🇨🇦 Canada (CA)",
     "MX": "🇲🇽 Mexico (MX)",
     "US": "🇺🇸 United States (US)",
+    # APAC backend (api.ecloudkr.com). The vehicle's actual area still comes
+    # from the login response; these countries are the common APAC ones.
+    "AU": "🇦🇺 Australia (AU)",
+    "HK": "🇭🇰 Hong Kong (HK)",
+    "ID": "🇮🇩 Indonesia (ID)",
+    "KR": "🇰🇷 South Korea (KR)",
+    "MY": "🇲🇾 Malaysia (MY)",
+    "NZ": "🇳🇿 New Zealand (NZ)",
+    "PH": "🇵🇭 Philippines (PH)",
+    "SG": "🇸🇬 Singapore (SG)",
+    "TH": "🇹🇭 Thailand (TH)",
+    "VN": "🇻🇳 Vietnam (VN)",
 }
 
 
@@ -183,11 +200,25 @@ def region_config(region: str | None) -> dict[str, str]:
     return REGIONS.get((region or DEFAULT_REGION).upper(), REGIONS[DEFAULT_REGION])
 
 
+# Market-area codes seen on /controlCars records that do NOT match the
+# backend region codes used elsewhere (REGIONS keys). saleMarket/tcamMarket
+# on APAC-market cars report "AP" (Asia-Pacific) while the backend key is
+# "APAC"; EU/NA records report codes that already match, so they pass
+# through unchanged.
+MARKET_TO_REGION: dict[str, str] = {
+    "AP": "APAC",
+}
+
+
 def resolve_vehicle_region(vehicle: dict) -> str | None:
     """Read the telematics area out of a /controlCars vehicle record.
 
     `tspInfo` is a list of per-service entries that each carry a
-    `serviceRegion`; `edgeInfo.code` carries the same area on some accounts."""
+    `serviceRegion`; `edgeInfo.code` carries the same area on some accounts.
+    Some backends (e.g. APAC/Korea) return a top-level `serviceRegion` field
+    instead of either of those, so fall back to it, and finally to the
+    `saleMarket` / `tcamMarket` market codes (e.g. "AP" -> APAC).
+    """
     tsp = vehicle.get("tspInfo")
     if isinstance(tsp, list):
         for entry in tsp:
@@ -196,6 +227,14 @@ def resolve_vehicle_region(vehicle: dict) -> str | None:
     edge = vehicle.get("edgeInfo")
     if isinstance(edge, dict) and edge.get("code"):
         return str(edge["code"]).upper()
+    top = vehicle.get("serviceRegion")
+    if top:
+        return str(top).upper()
+    for key in ("saleMarket", "tcamMarket"):
+        mkt = vehicle.get(key)
+        if mkt:
+            code = str(mkt).upper()
+            return MARKET_TO_REGION.get(code, code)
     return None
 
 

--- a/docs/APAC-SUPPORT.md
+++ b/docs/APAC-SUPPORT.md
@@ -1,0 +1,114 @@
+# Geely Connect — APAC region support (complete solution)
+
+**Status: working end-to-end, verified live (2026-08-03)**
+
+The [YossiKon/geely-connect](https://github.com/YossiKon/geely-connect) Home
+Assistant integration previously supported only **EU** and **NA**. This work
+adds full **APAC** support — region resolution, certificate provisioning and
+the runtime session exchange — verified live against a production account and
+vehicle (Australian-market Geely EX5).
+
+This document describes what was broken, the root causes, and the exact fix,
+so the same changes can be reviewed and merged.
+
+---
+
+## TL;DR — three independent problems
+
+1. **Region resolution.** APAC accounts' vehicle records carry no
+   `tspInfo` / `edgeInfo` / top-level `serviceRegion`, so region resolution
+   fell back to EU and the EU cert server rejected the account (`1501`).
+   **Fix:** resolve the region from `saleMarket` / `tcamMarket` (`"AP"` → APAC).
+
+2. **Request signing.** The APAC gateway enforces a different Accept header
+   and **uppercase** signature headers than the EU gateway:
+   - `Accept: application/json; charset=utf-8`
+     (the integration sent `application/json;responseformat=3` → gateway
+     rejects the signature with `1445`)
+   - **uppercase** `X-SIGNATURE` / `X-TIMESTAMP`
+     (the integration sent lowercase `X-signature` / `X-timestamp`)
+   - HMAC-SHA1 over the canonical string:
+     `Accept` + `\n` + sorted `x-api-*` headers (`name:value\n`) + `\n` +
+     sorted query params (`k=v&...`) + `\n` + `Base64(MD5(body))` + `\n` +
+     `timestamp_ms` + `\n` + `METHOD` + `\n` + path, signed with the
+     regional `app_secret`.
+   The signer was **byte-verified against the app's real SignUtil**
+   (HMAC-SHA1, key = the whitebox `app_secret`).
+
+3. **The session exchange.** APAC does **not** exchange the access code on
+   the mTLS control host like EU. It runs on the **public** host
+   `api.ecloudkr.com`:
+   - `POST /auth-center/account/session` (no query string, `urlname: user-api`)
+   - Body: `{"identityType": "geelyos", "authCode": <code>,
+     "receiverId": <login email>}`
+   - Success envelope differs from EU:
+     `{"resultCode": "0", "resultMessage": "Success", "accessToken": <JWT>,
+     "userId": <id>, "expiresIn": 7200}` — note `userId` here is the
+     session-service id, which differs from the cidpsso `user_id`; that is
+     normal.
+   - **The access code must be minted by the same regional backend that
+     exchanges it**: `POST /cidpsso/oauth2/v1/getCode` on
+     `m-lcmsam-kr.geely.com` (the APAC host). Codes minted on the EU/global
+     hosts do not exist in the APAC session store — the server crashes with
+     `8500` (`服务器端内部异常`). This was the root cause of the runtime
+     setup failure, and it is invisible from the client side: a garbage code
+     produces the identical `8500`, so the failure happens **before** code
+     validation.
+
+## Resulting APAC flow
+
+```
+OTP login (region-agnostic; unchanged)
+   → getCode on m-lcmsam-kr.geely.com            (regional code)
+   → POST api.ecloudkr.com /auth-center/account/session
+     {identityType, authCode, receiverId}        (public host, no mTLS)
+   → JWT (HS256, appId=GEELYE245, env=production, operator=GEELY)
+   → mTLS vehicle control on apis.ecloudkr.com   (client cert, pinned)
+     vehicle_status → code 1000 ✓
+```
+
+The mTLS client certificate is provisioned during config flow against
+`api.ecloudkr.com` (`/auth/cert/info` + `/auth/cert/file`) with
+`identityType: "geelyos"` — the same identity the session exchange uses.
+The APAC server pin for `apis.ecloudkr.com` is bundled (Geely private PKI,
+issuer "Geely Trust Center / External Services Issuing EU-CA").
+
+## Patch summary
+
+| File | Change |
+|---|---|
+| `const.py` | `REGIONS["APAC"]` (app_id, hosts, pin); `MARKET_TO_REGION` (`AP`→APAC); rewritten `resolve_vehicle_region()` (tspInfo → edgeInfo → top-level serviceRegion → market code); `SUPPORTED_COUNTRIES` += AU/NZ/KR/JP/SG/TH/MY/HK/ID/PH/VN; removed APAC from `UNSUPPORTED_REGIONS` |
+| `api.py` | `_get_access_code(host=...)` parameter; new `_apac_session_exchange()` (KR getCode → public-host session with `receiverId`, `resultCode` envelope); `refresh_jwt()` branches on `control_host == "apis.ecloudkr.com"`; `_PRIVATE_PKI_HOSTS` / `_BUNDLED_TLS_PINS` += `apis.ecloudkr.com` |
+| `config_flow.py` | region-provisioning log raised to ERROR level (the strings file promises that line; `system_log` only retains ERROR+) |
+| `__init__.py` | passes the stored login email into `GeelyApi` (used as `receiverId`) |
+
+## Verification
+
+- **Live end-to-end**: fresh JWT → `vehicle_status` on the mTLS control host
+  → `code 1000`, real vehicle data (engine state, position, charging state).
+- **HA integration**: entities populated with live values (charger voltage /
+  current / power, charge socket switch), zero errors in `system_log`.
+- **35/35 request-shape checks** (mock-based, against the exact bytes that
+  were verified live).
+
+## Known limitations (car-side, not integration-side)
+
+- The vehicle's T-Box enters deep sleep ~5 minutes after the last event when
+  the car is not charging or running. The server then stops receiving new
+  telemetry, so "last updated" timestamps freeze until the next wake event.
+  This is Geely vehicle firmware behaviour, not a limitation of this
+  integration.
+
+## Disclaimer
+
+Interoperability research and integration work, performed for private use
+with a vehicle owned by the operator. Not affiliated with or endorsed by
+Geely Automobile Holdings. API details and regional app identifiers are as
+embedded in the publicly distributed mobile application. If Geely objects to
+any part of this work, it will be taken down on request.
+
+---
+
+*Write-up of the full capture/extraction work exists separately (private);
+this document intentionally contains no personal data, no account tokens, and
+no device identifiers.*


### PR DESCRIPTION
## What this does

Adds **APAC** region support (AU, NZ, JP, KR, SG, TH, MY, HK, ID, PH, VN) to
the integration — region resolution, certificate provisioning, and the
runtime session exchange — verified live end-to-end against a production
Australian-market Geely EX5.

## Background

APAC was listed as "credentials not public" — the regional app id/secret were
not in the fork, and even with them the runtime setup failed with an opaque
`8500 服务器端内部异常` from the session service. This PR fixes three
independent problems:

### 1. Region resolution (`const.py`)
APAC vehicle records carry no `tspInfo` / `edgeInfo` / top-level
`serviceRegion`, so resolution fell back to EU and the EU cert server
rejected the account (`1501`). Added `MARKET_TO_REGION` and extended
`resolve_vehicle_region()` to fall back to `saleMarket`/`tcamMarket`
(`"AP"` → APAC) before the safe EU default.

### 2. APAC signing requirements (`api.py`)
The APAC gateway requires:
- `Accept: application/json; charset=utf-8` (the EU-style
  `application/json;responseformat=3` gets the signature rejected: `1445`)
- **uppercase** `X-SIGNATURE` / `X-TIMESTAMP` headers (lowercase variants are
  not picked up by the APAC gateway)
- the standard HMAC-SHA1 canonical-string signature, byte-verified against
  the app's real SignUtil

### 3. The APAC session exchange (`api.py`, `__init__.py`)
Unlike EU, APAC exchanges the access code on the **public** host
`api.ecloudkr.com` at `POST /auth-center/account/session` (no mTLS), with:
- body `{"identityType": "geelyos", "authCode": <code>,
  "receiverId": <login email>}`
- success envelope `{"resultCode": "0", "accessToken": <JWT>,
  "userId": <id>, "expiresIn": 7200}` (note: `userId` is the session-service
  id and differs from the cidpsso `user_id` — expected)
- **the access code must be minted by the APAC regional host
  (`m-lcmsam-kr.geely.com`)**. Codes from the EU/global hosts do not exist in
  the APAC session store and the server crashes with `8500` — which is the
  failure we originally chased. It is invisible client-side (a garbage code
  produces the identical `8500`, so it happens before code validation).

### Docs
`docs/APAC-SUPPORT.md` — full write-up including verification and the
car-side deep-sleep limitation. README region table updated.

## Verification

- Live end-to-end: `refresh_jwt` → mTLS `vehicle_status` → `code 1000` with
  real vehicle data (engine state, position, charging).
- HA integration: entities populated with live values, zero errors in
  `system_log`.
- 35/35 request-shape checks (mock-based, against the exact bytes verified
  live).

## Notes

- The mTLS client cert is provisioned during config flow against
  `api.ecloudkr.com` with `identityType: "geelyos"` (unchanged flow; APAC
  cert server accepts it).
- APAC pin for `apis.ecloudkr.com` bundled (Geely private PKI).
- Existing EU/NA flows are untouched — `refresh_jwt()` branches only when
  `control_host == "apis.ecloudkr.com"`.

## Test plan

- [x] Live account: region resolves to APAC, cert provisions, JWT exchanges,
      vehicle status reads (code 1000)
- [x] EU/NA code path regression-checked (unchanged mTLS flow)
- [ ] Existing EU/NA users: sanity-check by maintainers
