### PR TITLE
rename: climate entity to Remote Pre-Conditioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ back off removes the generated entities again.
 |---|---|
 | **Lock** | Lock / unlock the doors |
 | **Trunk** | Unlock the trunk |
-| **Climate** | On/off, set temperature (15.5-28.5 °C), Rapid Warming, Rapid Cooling |
+| **Climate (remote pre-conditioning)** | Remote pre-heat/pre-cool: on/off, set temperature (15.5-28.5 °C), Rapid Warming, Rapid Cooling. Only reflects remote pre-climate cycles - the cloud does not report manual cabin HVAC |
 | **Seat heating** | Driver & passenger (rear if supported): Off/Low/Medium/High |
 | **Seat ventilation** | Driver & passenger (rear if supported) |
 | **Defrost** | Windscreen defrost on/off |

--- a/custom_components/geely_connect/climate.py
+++ b/custom_components/geely_connect/climate.py
@@ -19,6 +19,14 @@ Target temp: NOT readable from any server endpoint. The Geely cloud's
 capability catalog explicitly lists `temperature_2` (which is the only
 remote_status temp query) as returning `temperature_in_car` only.
 We track the user-set value locally and surface it as `target_temperature`.
+
+Scope: this entity controls REMOTE pre-conditioning only. The Geely
+cloud does not report manual in-cabin HVAC operation - preClimateActive
+flips true only while a remote pre-climate cycle is running, and ends
+when the car starts (verified on EX5, 2026-08). A car driven with the
+cabin heater on still reports OFF here, exactly like the phone app,
+whose AC indicator is the same field. The entity name reflects that
+scope.
 """
 # -----------------------------------------------------------------------------
 # Portions of this file - the reverse-engineered Geely protocol / field mappings
@@ -152,7 +160,7 @@ class GeelyClimate(CoordinatorEntity, ClimateEntity, RestoreEntity):
         self._attr_supported_features = features
 
         self._attr_unique_id = f"geely_{self._vin}_climate"
-        self._attr_name = "Climate"
+        self._attr_name = "Remote Pre-Conditioning"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._vin)},
             manufacturer="Geely",


### PR DESCRIPTION
# Rename the climate entity to "Remote Pre-Conditioning"

## Summary

The climate entity is a **remote pre-conditioning** controller — it only
reflects remote pre-heat/pre-cool cycles. Its old display name "Climate"
implied it showed the live cabin HVAC state, which it cannot: a car driven
with the heater running shows `off`, because the Geely cloud simply does not
report manual in-cabin HVAC operation.

This PR renames the entity's display name to `Remote Pre-Conditioning` and
documents the scope in the module docstring and README.

## Why

`hvac_mode` turns ON solely from `preClimateActive` / `defrost`
(`custom_components/geely_connect/climate.py`). Both fields are set by the
Geely cloud **only while a remote pre-climate cycle is running** — the flag
goes false the moment the cycle ends or the car starts. Manual in-cabin
HVAC (driver presses heat/AC while driving) is not reported anywhere in the
API payload; the phone app has the same blind spot (its AC indicator reads
the same `preClimateActive` field).

Verified live on an APAC-market Geely EX5 (2026-08): during a 10-minute
drive with the cabin heater clearly running (interior temp 12.3 → 18.1 °C),
the climate entity stayed `off` at every poll because `preClimateActive`
remained false. Remote pre-warm fired from HA correctly showed `heat_cool`
until the cycle ended. The complete `climateStatus` payload contains no
field for manual HVAC state.

## Changes

- `custom_components/geely_connect/climate.py`
  - `_attr_name`: `"Climate"` → `"Remote Pre-Conditioning"`
  - Module docstring: added a "Scope" note explaining the entity reflects
    remote pre-conditioning only and why
- `README.md`
  - Features table row for Climate clarified:
    "Remote pre-heat/pre-cool: on/off, set temperature (15.5–28.5 °C),
    Rapid Warming, Rapid Cooling. Only reflects remote pre-climate cycles —
    the cloud does not report manual cabin HVAC"

## Non-breaking

Display name only. `_attr_unique_id` and the resulting `entity_id`
(`climate.my_geely_ex5_climate`) are unchanged, so existing installations
keep their entity, dashboards, and any entity-registry customizations
(which override this default name anyway).

## Test plan

- [ ] After reload, the climate entity's friendly name reads
      "Geely EX5 (… ) Remote Pre-Conditioning" (device name + entity name)
- [ ] Existing installs with a custom registry name are unaffected
- [ ] Remote pre-warm still shows `heat_cool` while a cycle runs, `off` at
      all other times

## Note for maintainers

"Remote Pre-Conditioning" is the tested choice from an affected user; if a
shorter label is preferred, "Remote Climate" also reads accurately. The
important part is dropping the implication of live cabin state.
