### PR TITLE
Efficiency and both consumption sensors can be read in miles

### DIFF
--- a/custom_components/geely_connect/sensor.py
+++ b/custom_components/geely_connect/sensor.py
@@ -206,6 +206,13 @@ _SENSOR_ICONS: dict[str, str] = {
     "power_consumption_trip": "mdi:lightning-bolt-outline",
 }
 
+# Home Assistant grew the energy_distance device class in 2025.3, and with it
+# the converter that puts mi/kWh in the unit picker (#37). hacs.json still
+# admits 2024.1, where the attribute is absent and reading it would fail the
+# import and take every entity down, so ask rather than assume.
+_ENERGY_DISTANCE = getattr(SensorDeviceClass, "ENERGY_DISTANCE", None)
+
+
 # (key, friendly_name, dotted-path, unit, device_class, value_type, value_map?)
 SENSOR_SPECS: tuple[tuple, ...] = (
     ("battery",             "Battery",              (*_EV,    "chargeLevel"),                          PERCENTAGE,                       SensorDeviceClass.BATTERY,     "float", None),
@@ -220,7 +227,7 @@ SENSOR_SPECS: tuple[tuple, ...] = (
     ("time_to_full_min",    "Time To Full Charge",  (*_EV,    "timeToFullyCharged"),                   "min",                            None,                          "minutes", None),
     ("12v_battery",         "12V Battery",          (*_MAINT, "mainBatteryStatus", "chargeLevel"),     PERCENTAGE,                       None,                          "float", None),
     ("12v_voltage",         "12V Voltage",          (*_MAINT, "mainBatteryStatus", "voltage"),         UnitOfElectricPotential.VOLT,     SensorDeviceClass.VOLTAGE,     "float", None),
-    ("avg_consumption",     "Average Consumption",  (*_EV,    "averPowerConsumption"),                 "kWh/100km",                      None,                          "float", None),
+    ("avg_consumption",     "Average Consumption",  (*_EV,    "averPowerConsumption"),                 "kWh/100km",                      _ENERGY_DISTANCE,              "float", None),
     ("trip_meter",          "Trip Meter",           (*_RUN,   "tripMeter1"),                           UnitOfLength.KILOMETERS,          SensorDeviceClass.DISTANCE,    "float", None),
     ("avg_speed",           "Average Speed",        (*_RUN,   "avgSpeed"),                             UnitOfSpeed.KILOMETERS_PER_HOUR,  SensorDeviceClass.SPEED,       "float", None),
     # Tyre temperatures, from the same TPMS sensors as the pressures below.
@@ -241,7 +248,7 @@ SENSOR_SPECS: tuple[tuple, ...] = (
     ("distance_to_service", "Distance To Service",  (*_MAINT, "distanceToService"),                    UnitOfLength.KILOMETERS,          SensorDeviceClass.DISTANCE,    "int",   None),
     # The trip twin of avg_consumption. The server has always sent both; only
     # the lifetime one was read, which made the pair look like one reading.
-    ("power_consumption_trip", "Trip Consumption",   (*_EV,    "averTraPowerConsumption"),              "kWh/100km",                      None,                          "float", None),
+    ("power_consumption_trip", "Trip Consumption",   (*_EV,    "averTraPowerConsumption"),              "kWh/100km",                      _ENERGY_DISTANCE,              "float", None),
 )
 
 # Only created for a car that burns fuel - see propulsion.py. A BEV reports none
@@ -734,6 +741,7 @@ class GeelyEfficiencySensor(CoordinatorEntity, _AutoPrecision):
     (server reports kWh/100km)."""
 
     _attr_has_entity_name = True
+    _attr_device_class = _ENERGY_DISTANCE
     _attr_native_unit_of_measurement = "km/kWh"
     _attr_icon = "mdi:leaf"
     _attr_state_class = SensorStateClass.MEASUREMENT

--- a/tests/test_computed_sensors.py
+++ b/tests/test_computed_sensors.py
@@ -67,6 +67,37 @@ def test_efficiency_is_none_when_the_field_is_absent():
     assert _make("GeelyEfficiencySensor", data).native_value is None
 
 
+def test_energy_per_distance_sensors_can_be_switched_to_miles():
+    """A unit picker only appears when the device class has a converter, and
+    energy_distance is the one carrying mi/kWh (#37). Two things have to hold:
+    the three entities must go through _ENERGY_DISTANCE rather than naming the
+    member directly, since it is absent before Home Assistant 2025.3, and their
+    unit strings must stay members of UnitOfEnergyDistance or Home Assistant
+    rejects the pair instead of converting it."""
+    if not have_homeassistant():
+        skip("homeassistant not installed")
+    from homeassistant.components.sensor import SensorDeviceClass
+    from homeassistant.components.sensor.const import DEVICE_CLASS_UNITS
+    from homeassistant.util.unit_conversion import EnergyDistanceConverter
+
+    sensor = load("sensor")
+    assert sensor._ENERGY_DISTANCE == SensorDeviceClass.ENERGY_DISTANCE
+    allowed = DEVICE_CLASS_UNITS[SensorDeviceClass.ENERGY_DISTANCE]
+
+    eff = _make("GeelyEfficiencySensor", _status())
+    assert eff.device_class is sensor._ENERGY_DISTANCE
+    assert eff.native_unit_of_measurement in allowed
+
+    for key in ("avg_consumption", "power_consumption_trip"):
+        spec = next(x for x in sensor.SENSOR_SPECS if x[0] == key)
+        assert spec[4] is sensor._ENERGY_DISTANCE, key
+        assert spec[3] in allowed, key
+
+    # 15.9 kWh/100km is what a real EX5 reports; a miles install reads 3.9.
+    assert round(EnergyDistanceConverter.convert(
+        15.9, "kWh/100km", "mi/kWh"), 1) == 3.9
+
+
 # ---------------------------------------------------------- full range ---
 
 def test_full_range_extrapolates_to_a_hundred_percent():


### PR DESCRIPTION
Efficiency, Average Consumption and Trip Consumption gain the `energy_distance` device class, which is what puts `mi/kWh` in Home Assistant's own unit picker. Nothing about the stored values or the native units changes. Refs #37: with these three done, every sensor that carries a distance is switchable from the entity dialog.

The one decision for you: the member landed in Home Assistant 2025.3 and `hacs.json` still admits 2024.1, so it goes through a `getattr` and an older core behaves exactly as it does today. Raising the floor to 2025.3 instead would be cleaner, and that is your call rather than mine.

Deliberately not included: a config-flow option (the `pressure_unit` pattern would fit, but which unit an owner wants is a UX decision, and the per-entity picker already answers the request) and any precision change, since `suggested_display_precision` keys off the native unit and one decimal is enough for a figure that moves while you drive.

751 passed, 0 failed, coverage still 100%. Reverting the `sensor.py` change on its own fails the new test, so it covers what it claims to.

Patched on my installation: 
<img width="562" height="521" alt="image" src="https://github.com/user-attachments/assets/f47381d1-7752-4e6a-8137-06ab9bda694b" />

<img width="466" height="327" alt="image" src="https://github.com/user-attachments/assets/8939a798-2954-4008-89f6-b6e5a1b34d98" />
