### PR TITLE
fix(card): the Service in row prints the owner's unit, and the pair stacks on a phone

### DIFF
--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -1804,8 +1804,8 @@
             ${this._row("12 V battery", this._st("sensor.12v_battery"))}
             ${this._row("Service in", days, {
               warn: OK(days) && NUM(days) != null && NUM(days) <= 30,
-              value: OK(days) ? `${days.state} d / ${OK(this._st("sensor.distance_to_service"))
-                ? this._st("sensor.distance_to_service").state + " km" : "—"}` : "—" })}
+              value: OK(days) ? `${this._fmt(days)} / ${OK(this._st("sensor.distance_to_service"))
+                ? this._fmt(this._st("sensor.distance_to_service")) : "—"}` : "—" })}
           </div>
 
           <div class="footer">
@@ -2256,8 +2256,8 @@
             ${this._row("12 V battery", this._st("sensor.12v_battery"))}
             ${this._row("Service in", days, {
               warn: OK(days) && NUM(days) != null && NUM(days) <= 30,
-              value: OK(days) ? `${days.state} d / ${OK(this._st("sensor.distance_to_service"))
-                ? this._st("sensor.distance_to_service").state + " km" : "—"}` : "—" })}
+              value: OK(days) ? `${this._fmt(days)} / ${OK(this._st("sensor.distance_to_service"))
+                ? this._fmt(this._st("sensor.distance_to_service")) : "—"}` : "—" })}
           </div>
 
           <div class="footer">

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -1697,6 +1697,14 @@
         .row span { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
         .row b { font-weight:500; color: var(--primary-text-color);
                  font-variant-numeric: tabular-nums; white-space:nowrap; }
+        /* Two columns stop fitting here: measured, the first label and
+         * value start ellipsising at 380px and a second pair follows by 340px
+         * (#47). One column at full width clips nothing at any width tested,
+         * so the pair stacks instead of being shortened. */
+        @container (max-width: 380px) {
+          .grid { grid-template-columns:minmax(0,1fr); }
+          .row b { overflow:hidden; text-overflow:ellipsis; }
+        }
         .row.accent b { color:${ACCENT}; }
         .row.warn b { color:${AMBER}; }
         .tires { display:grid; grid-template-columns:repeat(4,1fr); gap:8px; text-align:center; }
@@ -2164,6 +2172,14 @@
         .row span { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
         .row b { font-weight:500; color: var(--primary-text-color);
                  font-variant-numeric: tabular-nums; white-space:nowrap; }
+        /* Two columns stop fitting here: measured, the first label and
+         * value start ellipsising at 380px and a second pair follows by 340px
+         * (#47). One column at full width clips nothing at any width tested,
+         * so the pair stacks instead of being shortened. */
+        @container (max-width: 380px) {
+          .grid { grid-template-columns:minmax(0,1fr); }
+          .row b { overflow:hidden; text-overflow:ellipsis; }
+        }
         .row.accent b { color:${ACCENT}; }
         .row.warn b { color:${AMBER}; }
         .sec { margin-top:2px; }

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -726,6 +726,11 @@ _SERVICE_SCRIPT = r"""(arg) => {
         text: svc.textContent.replace(/\s+/g, " ").trim(),
         gridOverflow: Math.round(grid.scrollWidth - grid.clientWidth),
         valueClipped: b.scrollWidth > b.clientWidth,
+        clipped: [...grid.querySelectorAll(".row")].filter((r) => {
+          const l = r.querySelector("span"), v = r.querySelector("b");
+          return (l && l.scrollWidth > l.clientWidth)
+              || (v && v.scrollWidth > v.clientWidth);
+        }).map((r) => r.textContent.replace(/\s+/g, " ").trim()),
       };
       el.remove();
     }
@@ -752,6 +757,17 @@ def test_the_service_row_drops_the_hardcoded_unit_without_a_formatter():
     got = _evaluate(_SERVICE_SCRIPT, arg={"width": "460px", "withFmt": False})
     for tag, r in got.items():
         assert r["text"] == "Service in619 d / 16818.0326890957 mi", (tag, r)
+
+
+def test_the_pair_stacks_rather_than_shortening_anything_on_a_phone():
+    """A 1fr track floors at min-content, so one long cell widened the grid and
+    pushed the right-hand column off screen (#47). Shortening the value only
+    moved the problem: at 360px two columns ellipsise a label and a reading.
+    One column at full width clips nothing, so the pair stacks."""
+    got = _evaluate(_SERVICE_SCRIPT, arg={"width": "360px", "withFmt": True})
+    for tag, r in got.items():
+        assert r["gridOverflow"] == 0, (tag, r)
+        assert r["clipped"] == [], (tag, r["clipped"])
 
 
 # ------------------------------------------- #29: the climate row on a phone

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -687,6 +687,73 @@ def test_a_home_assistant_without_the_formatter_still_gets_a_value():
     assert got["fallback"] == "Odometer7730.479002662467 mi", got
 
 
+# --------------------------- #47: the Service in cell and the grid it widened
+
+_SERVICE_SCRIPT = r"""(arg) => {
+    const out = {};
+    for (const tag of ["geely-card", "geely-card-top"]) {
+      const el = document.createElement(tag);
+      document.body.appendChild(el);
+      el.setConfig({});
+      el.style.width = arg.width;
+      const hass = window.mkHass({});
+      // The whole block, because 1fr columns are sized against every row: two
+      // of them leave the long cell room the real card never gives it.
+      const put = (id, st, u) => { hass.states[id] = {entity_id: id, state: st,
+          attributes: {unit_of_measurement: u}}; };
+      put("sensor.car_total_mileage", "3192.60518571542", "mi");
+      put("sensor.car_trip_meter", "3192.72945995387", "mi");
+      put("sensor.car_average_consumption", "15.9", "kWh/100km");
+      put("sensor.car_efficiency", "3.908", "mi/kWh");
+      // A miles install: both halves arrive converted, with the precision in
+      // the registry rather than on the state.
+      put("sensor.car_days_to_service", "619", "d");
+      put("sensor.car_distance_to_service", "16818.0326890957", "mi");
+      if (arg.withFmt) {
+        hass.formatEntityState = (st) => {
+          const u = st.attributes.unit_of_measurement || "";
+          const n = u === "mi"
+            ? Math.round(Number(st.state)).toLocaleString("en") : st.state;
+          return u ? `${n} ${u}` : `${n}`;
+        };
+      }
+      el.hass = hass;
+      const grid = [...el.shadowRoot.querySelectorAll(".grid.sec")].pop();
+      const svc = [...grid.querySelectorAll(".row")].find(
+          (r) => r.textContent.indexOf("Service in") >= 0);
+      const b = svc.querySelector("b");
+      out[tag] = {
+        text: svc.textContent.replace(/\s+/g, " ").trim(),
+        gridOverflow: Math.round(grid.scrollWidth - grid.clientWidth),
+        valueClipped: b.scrollWidth > b.clientWidth,
+      };
+      el.remove();
+    }
+    return out;
+}"""
+
+
+def test_the_service_row_prints_the_owners_unit():
+    """This cell passed its own `value`, so it never reached `_fmt`: it printed
+    the raw state and appended a hardcoded " km". On a miles install that reads
+    "16818.0326890957 km", wrong on both counts (#47). Asserted at a width
+    where the value fits, and pinned as unclipped, so the text this claims is
+    on screen really is."""
+    got = _evaluate(_SERVICE_SCRIPT, arg={"width": "460px", "withFmt": True})
+    for tag, r in got.items():
+        assert r["text"] == "Service in619 d / 16,818 mi", (tag, r)
+        assert not r["valueClipped"], (tag, r)
+
+
+def test_the_service_row_drops_the_hardcoded_unit_without_a_formatter():
+    """The fallback path changed too, since the old code appended " km"
+    whatever the entity said. An older Home Assistant now gets the entity's own
+    unit rather than a wrong one."""
+    got = _evaluate(_SERVICE_SCRIPT, arg={"width": "460px", "withFmt": False})
+    for tag, r in got.items():
+        assert r["text"] == "Service in619 d / 16818.0326890957 mi", (tag, r)
+
+
 # ------------------------------------------- #29: the climate row on a phone
 
 _ROWS_PROBE = """(() => {


### PR DESCRIPTION
The "Service in" cell passed its own `value` to `_row`, so it never reached `_fmt`: it printed the raw state and appended a hardcoded `" km"`, which on a miles install reads `619 d / 16818.0326890957 km` where the entity says `16,818 mi`. That value cannot break and a `1fr` track floors at min-content, so the column widened past its container and the whole right-hand side left the card, labels holding position while the readings went off screen. Fixes #47.

Two commits, because formatting is only most of the answer. It takes the value from 154px to 89px and clears the overflow down to 380px, but below that two columns ellipsise `Consumption` and its reading instead. One column clips nothing at any width tested down to 340px, so the pair stacks below the `@container (max-width: 380px)` breakpoint #29 already established, and nothing changes above it.

`geely-card.js` only, both affected variants, no Python. 825 passed, coverage still 100%, and revert audited both ways: reverting the formatting fails the two text cases, reverting the CSS fails the stacking case. Also running on a live EX5 in miles.

Two notes. I opened #47, so this is self-reported with no second owner confirming, and `manifest.json` is left at 1.42.0 since you cut the releases. Unrelated: the status banner at `geely-card.js:1669` and `2116` has the same shape, raw `power.state` plus a hardcoded `" kW"`, so a sensor switched to W would read "7000 kW". Worth its own issue.

**Before**
<img width="1220" height="2712" alt="WhatsApp Image 2026-08-22 at 15 01 09" src="https://github.com/user-attachments/assets/1ed9bf2b-283b-43b6-9080-23fd84f47961" />

**After**
<img width="1220" height="2712" alt="WhatsApp Image 2026-08-23 at 09 59 40" src="https://github.com/user-attachments/assets/5378fb05-8fdd-4bf1-9ec0-4382e212a691" />

On larger devices 
<img width="594" height="494" alt="image" src="https://github.com/user-attachments/assets/5e83a0ac-d4b1-4e18-bac0-83f00b0209ea" />
