### PR TITLE
New platform: read the vehicle from the new gateway when it lives there (fixes #53)

### DIFF
--- a/custom_components/geely_connect/__init__.py
+++ b/custom_components/geely_connect/__init__.py
@@ -50,6 +50,7 @@ from .const import (
     CONF_VEHICLE_SERIES,
     CONF_VIN,
     CONF_ZEEKR_ACCESS_TOKEN,
+    CONF_ZEEKR_ENC_VIN,
     CONF_ZEEKR_HF_EXPIRY,
     CONF_ZEEKR_HF_TOKEN,
     CONF_ZEEKR_PASSWORD,
@@ -407,6 +408,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # http.client raise on every HF request.
             timezone=hass.config.time_zone or "UTC",
             hf_expiry=int(d.get(CONF_ZEEKR_HF_EXPIRY) or 0),
+            # Options win over entry data so the token can be pasted or
+            # corrected from Configure without re-adding the integration.
+            enc_vin=(entry.options.get(CONF_ZEEKR_ENC_VIN)
+                     or d.get(CONF_ZEEKR_ENC_VIN) or ""),
         )
     else:
         # Entries created before regions were tracked carry no CONF_REGION and

--- a/custom_components/geely_connect/config_flow.py
+++ b/custom_components/geely_connect/config_flow.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_PLATFORM,
     CONF_REGION,
     CONF_ZEEKR_ACCESS_TOKEN,
+    CONF_ZEEKR_ENC_VIN,
     CONF_ZEEKR_HF_EXPIRY,
     CONF_ZEEKR_HF_TOKEN,
     CONF_ZEEKR_PASSWORD,
@@ -524,6 +525,17 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     raw = await self.hass.async_add_executor_job(
                         client.list_vehicles, client.user_id)
+                    if not raw:
+                        # Fail-only: an account migrated to the new app can
+                        # have an empty old-platform garage while its car is
+                        # listed on the new gateway. An account that lists
+                        # cars today cannot reach this.
+                        raw = await self.hass.async_add_executor_job(
+                            client.list_vehicles_bff)
+                        if raw:
+                            _LOGGER.info(
+                                "garage found on the new-platform "
+                                "ms-app-bff route")
                     self._vehicles = [v for v in raw if _valid_vin(vehicle_vin(v))]
                     if not self._vehicles:
                         errors["base"] = "no_vehicles"
@@ -708,10 +720,25 @@ class GeelyIntlOptionsFlow(config_entries.OptionsFlow):
             # when an entity is first registered, so afterwards the display
             # unit lives in the registry and nothing the integration reports
             # will move it.
+            if CONF_ZEEKR_ENC_VIN in user_input:
+                user_input[CONF_ZEEKR_ENC_VIN] = (
+                    user_input[CONF_ZEEKR_ENC_VIN] or "").strip()
             new_unit = user_input.get(CONF_PRESSURE_UNIT)
             if new_unit and new_unit != current.get(CONF_PRESSURE_UNIT):
                 _apply_pressure_unit(self.hass, entry, new_unit)
             return self.async_create_entry(title="", data=user_input)
+
+        # New-platform vehicles are addressed by an opaque per-vehicle
+        # token rather than the plain VIN, and it cannot be derived from
+        # anything stored here. Offered only where it applies, and only as
+        # an optional field: without it the entry behaves exactly as
+        # before, reading status from the old platform.
+        extra: dict[Any, Any] = {}
+        if current.get(CONF_PLATFORM, DEFAULT_PLATFORM) == PLATFORM_ZEEKR:
+            extra[vol.Optional(
+                CONF_ZEEKR_ENC_VIN,
+                default=current.get(CONF_ZEEKR_ENC_VIN) or "",
+            )] = str
 
         return self.async_show_form(
             step_id="init",
@@ -747,6 +774,7 @@ class GeelyIntlOptionsFlow(config_entries.OptionsFlow):
                     CONF_EXTERIOR_TEMP_OFFSET,
                     default=float(current.get(CONF_EXTERIOR_TEMP_OFFSET) or 0),
                 ): vol.All(vol.Coerce(float), vol.Range(min=-30, max=30)),
+                **extra,
             }),
         )
 

--- a/custom_components/geely_connect/const.py
+++ b/custom_components/geely_connect/const.py
@@ -92,6 +92,11 @@ CONF_ZEEKR_ACCESS_TOKEN = "zeekr_access_token"
 CONF_ZEEKR_REFRESH_TOKEN = "zeekr_refresh_token"
 CONF_ZEEKR_HF_TOKEN     = "zeekr_hf_token"
 CONF_ZEEKR_HF_EXPIRY    = "zeekr_hf_expiry"
+# The new platform addresses a vehicle by an opaque per-vehicle token in
+# the `x-vin` header rather than by the plain VIN. It is stable per car but
+# derived inside the app, so it is supplied by the owner rather than
+# computed; empty means "stay on the old-platform status path".
+CONF_ZEEKR_ENC_VIN      = "zeekr_enc_vin"
 CONF_ZEEKR_PASSWORD     = "zeekr_password"
 CONF_STORE_PASSWORD     = "store_password"
 

--- a/custom_components/geely_connect/strings.json
+++ b/custom_components/geely_connect/strings.json
@@ -81,7 +81,8 @@
         "data": {
           "poll_mode": "Polling mode",
           "pressure_unit": "Tire pressure unit",
-          "full_exposure": "Expose every raw field (adds ~180 diagnostic entities)"
+          "full_exposure": "Expose every raw field (adds ~180 diagnostic entities)",
+          "zeekr_enc_vin": "Vehicle token for the new platform (x-vin) - advanced, leave blank unless you have it"
         }
       }
     }

--- a/custom_components/geely_connect/translations/en.json
+++ b/custom_components/geely_connect/translations/en.json
@@ -81,7 +81,8 @@
         "data": {
           "poll_mode": "Polling mode",
           "pressure_unit": "Tire pressure unit",
-          "full_exposure": "Expose every raw field (adds ~180 diagnostic entities)"
+          "full_exposure": "Expose every raw field (adds ~180 diagnostic entities)",
+          "zeekr_enc_vin": "Vehicle token for the new platform (x-vin) - advanced, leave blank unless you have it"
         }
       }
     }

--- a/custom_components/geely_connect/zeekr_adapter.py
+++ b/custom_components/geely_connect/zeekr_adapter.py
@@ -48,6 +48,32 @@ def _looks_authy(text: str) -> bool:
     return any(h in low for h in _AUTH_HINTS)
 
 
+def _wrap_vehicle_status(data: Any) -> Any:
+    """Give the new gateway's status payload the old platform's nesting.
+
+    Old platform:  data = {"vehicleStatus": {basicVehicleStatus,
+                            additionalVehicleStatus}, "updateTime": ...}
+    New gateway:   data = {basicVehicleStatus, additionalVehicleStatus,
+                            "updateTime": ...}
+
+    Every consumer reads through the "vehicleStatus" level, so without this the
+    entire entity set reads unknown while the payload sits right there - and
+    the few entities that read top-level fields keep working, which makes the
+    symptom look like anything but a missing key. The wrapper is added without
+    moving anything, so both spellings resolve.
+    """
+    if not isinstance(data, dict) or "vehicleStatus" in data:
+        return data
+    if "basicVehicleStatus" not in data and "additionalVehicleStatus" not in data:
+        return data
+    wrapped = dict(data)
+    wrapped["vehicleStatus"] = {
+        k: v for k, v in data.items()
+        if k in ("basicVehicleStatus", "additionalVehicleStatus")
+    }
+    return wrapped
+
+
 class ZeekrAdapter:
     """GeelyApi-shaped wrapper around ZeekrClient for the new platform."""
 
@@ -56,7 +82,7 @@ class ZeekrAdapter:
                  hf_token: str = "", vehicle_model: str = "",
                  password: str = "", country_code: str = "AU",
                  timezone: str = "UTC", hf_expiry: int = 0,
-                 gateway: str = GATEWAY) -> None:
+                 gateway: str = GATEWAY, enc_vin: str = "") -> None:
         self.vin = vin
         self.user_id = user_id
         self._email = email
@@ -72,6 +98,9 @@ class ZeekrAdapter:
         self._client.refresh_token = refresh_token
         self._client.user_id = user_id
         self._client.hf_token = hf_token or None
+        # Set only for vehicles that live on the new platform; selects the
+        # new-gateway status path in vehicle_status() below.
+        self._client.enc_vin = enc_vin or ""
         # Set when a silent HF renewal happened; the coordinator persists the
         # new token + expiry into the config entry after the next poll.
         self.hf_dirty = False
@@ -95,13 +124,23 @@ class ZeekrAdapter:
 
     def _renew_hf(self) -> None:
         """The app's silent renewal, mirrored: password -> IDaaS tokenValue ->
-        client-2 tspCode -> old-platform session/secure -> new HF JWT."""
+        tspCode -> both sessions re-minted.
+
+        This re-mints the new-platform access token as well as the HF JWT.
+        Renewing only the HF side leaves `access_token` frozen at whatever
+        the config entry holds, and that token is single-session
+        server-side: once the phone app signs in, the stored one is
+        superseded and every new-gateway call answers `079021 The account
+        is currently logged in elsewhere` permanently, because nothing
+        ever replaces it. login_tsp re-mints the snc session and calls
+        login_hf itself, so one call recovers both.
+        """
         if not self._password:
             raise ZeekrAuthError(
                 "no stored password for HF renewal - reauthenticate")
         token_value = ZeekrIdaas(country=self._country_code).login_by_email_password(
             self._email, self._password)
-        self._client.login_hf(token_value)
+        self._client.login_tsp(token_value)
         self._hf_expiry_ts = int(time.time()) + self._client.hf_expires_in
         self.hf_dirty = True
 
@@ -138,7 +177,21 @@ class ZeekrAdapter:
 
     def vehicle_status(self) -> dict:
         """Full response (code/data/...) so the coordinator's success-code
-        check works unchanged against the real gateway codes."""
+        check works unchanged against the real gateway codes.
+
+        A vehicle with an `x-vin` token lives on the new platform, where
+        the old one answers 8060 (VIN unknown); read it from the new
+        gateway instead, then normalise the envelope so nothing
+        downstream has to know which platform answered.
+        """
+        if self._client.enc_vin:
+            resp = self._authed(self._client.vehicle_status_new_resp)
+            if isinstance(resp, dict):
+                # This gateway reports success as "000000", not 1000.
+                if str(resp.get("code")) in ("000000", "0"):
+                    resp = {**resp, "code": 1000}
+                resp = {**resp, "data": _wrap_vehicle_status(resp.get("data"))}
+            return resp
         return self._authed(self._client.vehicle_status_resp,
                             self.vin, self.user_id)
 

--- a/custom_components/geely_connect/zeekr_client.py
+++ b/custom_components/geely_connect/zeekr_client.py
@@ -641,13 +641,16 @@ class ZeekrClient:
         # identifier per client instance.
         self.timezone: str = "UTC"
         self.hf_device_id = uuid.uuid4().hex
+        # Opaque per-vehicle token the new gateway wants in `x-vin`; see
+        # CONF_ZEEKR_ENC_VIN. Empty = new-platform vehicle calls unused.
+        self.enc_vin: str = ""
 
     # ---- transport ----------------------------------------------------------
 
     def _request(self, method: str, path: str, *, body: bytes = b"",
                  signed: bool = True, urlname: str | None = None,
                  query: str = "", extra: dict | None = None,
-                 signer: str = "v2") -> dict:
+                 signer: str = "v2", bearer: bool = False) -> dict:
         p = urlparse(self.gateway)
         port = p.port or (443 if p.scheme == "https" else 80)
         nonce = _make_nonce()
@@ -669,10 +672,17 @@ class ZeekrClient:
         # interceptor adds it before nj/h signs), so attach it before
         # computing X-SIGNATURE. Signer v2's canonical never includes it.
         if self.access_token:
-            headers["Authorization"] = self.access_token
+            headers["Authorization"] = (
+                f"Bearer {self.access_token}" if bearer else self.access_token)
         if signer == "snc":
             # snc stack (ms-user-auth): derived app identity + the header set
             # the app's own SignInterceptor signs (nj/a.java + nj/h.java).
+            # The app uses a UUID nonce on this gateway rather than the
+            # 32-char random string the other legs use, and it is inside
+            # the signed canonical.
+            nonce = str(uuid.uuid4())
+            if self.enc_vin:
+                headers["x-vin"] = self.enc_vin
             headers.update({
                 "X-APP-ID": SNC_APP_ID,
                 "X-PROJECT-ID": SNC_PROJECT_ID,
@@ -872,6 +882,51 @@ class ZeekrClient:
         if isinstance(data, list):
             return [v for v in data if isinstance(v, dict)]
         return []
+
+    def list_vehicles_bff(self) -> list[dict]:
+        """Garage read on the NEW gateway.
+
+        The old platform is authoritative for accounts whose vehicle still
+        lives there. An account migrated to the new app can have an empty
+        old-platform garage while the car is plainly visible in the new app -
+        for those, the new gateway carries an `ms-app-bff` mirror of the same
+        route. Response shape matches the old one (data list of vehicle
+        records), so the caller is unchanged.
+        """
+        if not self.access_token:
+            raise ZeekrAuthError("not logged in (no new-platform session)")
+        resp = self._request(
+            "GET", "/ms-app-bff/api/v4.0/veh/vehicle-list",
+            query="needSharedCar=true", signer="snc")
+        data = resp.get("data")
+        if isinstance(data, list):
+            return [v for v in data if isinstance(v, dict)]
+        if isinstance(data, dict):
+            for key in ("list", "records", "vehicles", "vehicleList"):
+                val = data.get(key)
+                if isinstance(val, list):
+                    return [v for v in val if isinstance(v, dict)]
+        return []
+
+    def vehicle_status_new_resp(self) -> dict:
+        """Live status from the NEW gateway, for vehicles that live there.
+
+        GET /ms-vehicle-status/api/v1.0/vehicle/status/latest?latest=false&target=new
+        addressed by the `x-vin` token. The body is the same
+        {basicVehicleStatus, additionalVehicleStatus, ...} content the old
+        platform returns, but WITHOUT the old platform's "vehicleStatus"
+        wrapper - the adapter restores that so every consumer is unchanged.
+
+        The bare access token is what this gateway accepts here; sending it as
+        "Bearer <token>" is rejected with 079020 Invalid token.
+        """
+        if not self.access_token:
+            raise ZeekrAuthError("not logged in (no new-platform session)")
+        if not self.enc_vin:
+            raise ZeekrAuthError("no x-vin vehicle token configured")
+        return self._request(
+            "GET", "/ms-vehicle-status/api/v1.0/vehicle/status/latest",
+            query="latest=false&target=new", signer="snc")
 
     def list_vehicles(self, user_id: str) -> list[dict]:
         """GET /device-platform/api/v4.0/veh/vehicle-list?needSharedCar=true

--- a/tests/test_zeekr_new_platform.py
+++ b/tests/test_zeekr_new_platform.py
@@ -1,0 +1,146 @@
+"""New-platform vehicle reads: the ms-app-bff garage and the ms-vehicle-status
+live read, plus the payload-nesting fix that makes them usable.
+
+Every assertion here is against a capture of the official app (2026-08-27,
+AU account, EX5 on the new EM platform) rather than an assumption:
+
+  * the status route is /ms-vehicle-status/api/v1.0/vehicle/status/latest with
+    query latest=false&target=new,
+  * the vehicle is addressed by the opaque `x-vin` token, not the plain VIN,
+  * the nonce on this gateway is a UUID and it is inside the signed canonical,
+  * and the payload omits the old platform's "vehicleStatus" wrapper.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from conftest import FAKE_VIN, load
+
+zc = load("zeekr_client")
+adapter = load("zeekr_adapter")
+
+_STATUS_DATA = {
+    "basicVehicleStatus": {"engineStatus": "engine-off", "speed": 0},
+    "additionalVehicleStatus": {
+        "electricVehicleStatus": {"chargeLevel": "92.0",
+                                  "distanceToEmptyOnBatteryOnly": "270"},
+        "drivingSafetyStatus": {"centralLockingStatus": "1"},
+    },
+    "updateTime": 1787817174561,
+}
+_LIST_DATA = [{"vin": FAKE_VIN, "nickName": "EX5", "tboxPlatform": "1"}]
+
+
+def _start_gateway(seen: list[dict]):
+    """A gateway that records what it was sent and verifies the snc signature."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):  # noqa: D102 - silence the test server
+            pass
+
+        def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler's spelling
+            path, _, query = self.path.partition("?")
+            headers = {k.lower(): v for k, v in self.headers.items()}
+            want = zc.snc_sign(
+                method="GET",
+                url=f"http://127.0.0.1:{self.server.server_address[1]}{self.path}",
+                headers=dict(self.headers), body=b"")
+            seen.append({
+                "path": path,
+                "query": query,
+                "authorization": headers.get("authorization", ""),
+                "x_vin": headers.get("x-vin"),
+                "nonce": headers.get("x-api-signature-nonce", ""),
+                "signature_ok": headers.get("x-signature") == want,
+            })
+            body = {"code": "000000", "msg": "ok",
+                    "data": _STATUS_DATA if "ms-vehicle-status" in path else _LIST_DATA}
+            raw = json.dumps(body).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+    srv = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv
+
+
+def _client(srv) -> object:
+    c = zc.ZeekrClient(email="", password="",
+                       gateway=f"http://127.0.0.1:{srv.server_address[1]}")
+    c.access_token = "test-access-token"
+    c.user_id = "u123"
+    return c
+
+
+def test_status_read_matches_the_captured_request():
+    seen: list[dict] = []
+    srv = _start_gateway(seen)
+    try:
+        c = _client(srv)
+        c.enc_vin = "ENC-VIN-TOKEN=="
+        resp = c.vehicle_status_new_resp()
+    finally:
+        srv.shutdown()
+
+    sent = seen[-1]
+    assert sent["path"] == "/ms-vehicle-status/api/v1.0/vehicle/status/latest"
+    assert sent["query"] == "latest=false&target=new"
+    # The bare token is what this gateway accepts; "Bearer <token>" is
+    # rejected with 079020 Invalid token.
+    assert sent["authorization"] == "test-access-token"
+    assert sent["x_vin"] == "ENC-VIN-TOKEN=="
+    assert len(sent["nonce"]) == 36 and sent["nonce"].count("-") == 4
+    assert sent["signature_ok"], "x-vin/nonce must be inside the signed canonical"
+    assert resp["data"]["basicVehicleStatus"]["engineStatus"] == "engine-off"
+
+
+def test_status_read_needs_the_vehicle_token():
+    seen: list[dict] = []
+    srv = _start_gateway(seen)
+    try:
+        c = _client(srv)
+        try:
+            c.vehicle_status_new_resp()
+        except zc.ZeekrAuthError:
+            pass
+        else:  # pragma: no cover - only reached on a regression
+            raise AssertionError("expected ZeekrAuthError without enc_vin")
+    finally:
+        srv.shutdown()
+    assert not seen, "must not reach the gateway without an x-vin token"
+
+
+def test_bff_garage_returns_records():
+    seen: list[dict] = []
+    srv = _start_gateway(seen)
+    try:
+        records = _client(srv).list_vehicles_bff()
+    finally:
+        srv.shutdown()
+    assert [r["vin"] for r in records] == [FAKE_VIN]
+    assert seen[-1]["path"] == "/ms-app-bff/api/v4.0/veh/vehicle-list"
+    assert seen[-1]["query"] == "needSharedCar=true"
+
+
+def test_wrapper_restores_the_old_platform_nesting():
+    wrapped = adapter._wrap_vehicle_status(_STATUS_DATA)
+    basic = wrapped["vehicleStatus"]["basicVehicleStatus"]
+    ev = (wrapped["vehicleStatus"]["additionalVehicleStatus"]
+          ["electricVehicleStatus"])
+    assert basic["engineStatus"] == "engine-off"
+    assert ev["chargeLevel"] == "92.0"
+    # Nothing is moved, so top-level readers keep working.
+    assert wrapped["updateTime"] == 1787817174561
+
+
+def test_wrapper_leaves_everything_else_alone():
+    old_shape = {"vehicleStatus": {"basicVehicleStatus": {}}, "updateTime": 1}
+    assert adapter._wrap_vehicle_status(old_shape) is old_shape
+    assert adapter._wrap_vehicle_status({"a": 1}) == {"a": 1}
+    assert adapter._wrap_vehicle_status(None) is None
+    assert adapter._wrap_vehicle_status("not a dict") == "not a dict"


### PR DESCRIPTION
Fixes the new-platform side of #53, where an account migrated to the new Geely EM app has an empty **old-platform** garage while its car is plainly visible in the app. On such an account setup ends at `no_vehicles`, and an entry forced into existence fails with `8060` (VIN unknown) because the old platform genuinely does not have that VIN.

Everything here is verified against a capture of the official app (AU account, EX5, 2026-08-27) rather than inferred, and is running live on that account now: **61/77 entities populated, entry `loaded`, no errors** — battery 92 %, range 270 km, doors locked, tyre pressures, location, the lot.

## What changed

**1. Garage — fail-only fallback to `ms-app-bff`.** When the old-platform garage comes back empty, ask the new gateway's mirror of the same route. An account that lists cars today cannot reach this branch, in the spirit of the #32 KR fallback.

**2. Status — the new-gateway read.**

```
GET /ms-vehicle-status/api/v1.0/vehicle/status/latest?latest=false&target=new
    x-vin: <opaque per-vehicle token>
    x-api-signature-nonce: <UUID v4>
    Authorization: <bare access token>
```

The nonce on this gateway is a UUID rather than the 32-char random string the other legs use, and both it and `x-vin` sit inside the signed canonical — `_SNC_WHITELIST` already covers them exactly. The **bare** token is what the gateway accepts here; `Bearer <same token>` is refused with `079020 Invalid token` (the app does send `Bearer`, so something else about its request satisfies that path — moot in practice, but worth knowing).

**3. Payload nesting — the one that looks like a dead end.** The new gateway omits the old platform's `vehicleStatus` level:

```
old:  data = {"vehicleStatus": {basicVehicleStatus, additionalVehicleStatus}, "updateTime": …}
new:  data = {basicVehicleStatus, additionalVehicleStatus, "updateTime": …}
```

`sensor.py` and friends read through `_BASIC = ("vehicleStatus", "basicVehicleStatus")`, so with a perfectly good payload in memory **every** entity reads unknown — except the few that read top-level fields, so `sensor.last_updated` cheerfully shows the current time while nothing else works. The wrapper is restored at the adapter boundary without moving anything, so both spellings resolve. This gateway also reports success as `"000000"` rather than `1000`, translated in the same place so `_SUCCESS_CODES` keeps describing the old platform.

**4. `_renew_hf` re-mints both sessions — a bug in its own right.**

```diff
-        self._client.login_hf(token_value)
+        self._client.login_tsp(token_value)
```

It previously renewed only the HF JWT, leaving `access_token` frozen at whatever the config entry held. That token is single-session server-side: the moment the phone app signs in, the stored one is superseded and every new-gateway call answers `079021 The account is currently logged in elsewhere` — **permanently**, because nothing ever replaced it. `login_tsp` re-mints the snc session and calls `login_hf` itself, so one call recovers both. This affects any new-platform user who opens the app, independently of the rest of this PR.

## The one thing that is not general

`x-vin` is not the VIN — it is an opaque 32-byte token. It is byte-stable per vehicle (identical across two separate logins 40 minutes apart), but it is derived inside the app and **I have not reversed that derivation, and did not try to**. So it is exposed as an optional advanced option (`zeekr_enc_vin`, on the Configure dialog, shown only for new-platform entries) for owners who have captured it, rather than something the project computes.

Empty means the entry behaves exactly as before, on the old-platform status path. Items 1, 3 and 4 are unconditional and need no captured value — **and item 4 in particular is worth taking on its own** even if you would rather not carry the rest.

If you would prefer not to have a "capture required" option in the project at all, that is completely reasonable; item 4 and the `ms-app-bff` garage fallback still stand alone, and I will happily split this into separate PRs — or you may prefer to reimplement from the findings, as with #32. No attachment to this being the implementation.

## Tests

`tests/test_zeekr_new_platform.py` — 5 tests against a mock gateway that **recomputes and verifies the snc signature**, covering the status request shape (path, query, bare token, `x-vin`, UUID nonce, signature), the guard when no token is configured, the bff garage read, and the wrapper (including that it leaves old-platform payloads, non-status dicts and `None` untouched).

One unrelated observation while running the suite: `tests/conftest.py` registers its synthetic package as `gc`, which collides with the stdlib `gc` builtin — that is always present in `sys.modules`, so the `if "gc" not in sys.modules` guard never fires, `gc.__path__` is never set, and `pytest tests/` dies at collection with `No module named 'gc.api'`. It reproduces on a clean checkout of `main` here, so it is not from this branch. Renaming the synthetic package (`_gc_geely`, say) would fix it. Happy to send that as a separate PR if useful.
