### PR TITLE
New platform: the lock/unlock/climate command mapping

### DIFF
--- a/custom_components/geely_connect/zeekr_adapter.py
+++ b/custom_components/geely_connect/zeekr_adapter.py
@@ -173,6 +173,25 @@ def _translate_command(service_id: str, command: str,
     """
     p = {q.get("key"): q.get("value") for q in (parameters or [])}
 
+    if service_id == "RDL_2":                       # lock
+        return "RDL", "start", [{"key": "door", "value": "all"}]
+
+    if service_id == "RDU_2":
+        # RDU is a general "open" service selected by target; the command
+        # differs per target. Directions were checked against the car's own
+        # centralLockingStatus, not the names: RDU+stop UNLOCKS, RDL+start
+        # LOCKS. Mapped the other way round lock.lock silently unlocks the
+        # car - single-source, so this waits on a second owner confirming
+        # the cycle before it should be trusted.
+        target = p.get("target")
+        if target == "trunk":                       # tailgate
+            return "RDU", "stop", [{"key": "target", "value": "trunk"}]
+        if target == "hood":                        # frunk (no entity yet)
+            return "RDU", "start", [{"key": "target", "value": "hood"}]
+        if target:
+            return None
+        return "RDU", "stop", [{"key": "door", "value": "all"}]   # unlock
+
     if service_id in ("RCE_2", "RCE"):
         level = p.get("rce.level")
         seat = p.get("rce.heat") or p.get("rce.ventilation")

--- a/tests/test_zeekr_new_platform_commands.py
+++ b/tests/test_zeekr_new_platform_commands.py
@@ -69,3 +69,29 @@ def test_air_clean_maps_to_rcc():
 
 def test_an_uncaptured_service_is_refused():
     assert tc("SOMETHING_NEW", "start", []) is None
+
+
+# ---- lock / unlock -----------------------------------------------------
+# The directions are the held part: verified against centralLockingStatus,
+# not the service names, because RDU+stop UNLOCKS and RDL+start LOCKS. This
+# stays single-source until a second new-platform owner confirms the cycle.
+
+def test_lock_is_rdl_start():
+    assert tc("RDL_2", "start", [{"key": "door", "value": "all"}]) == (
+        "RDL", "start", [{"key": "door", "value": "all"}])
+
+
+def test_unlock_is_rdu_stop():
+    assert tc("RDU_2", "start", [{"key": "door", "value": "all"}]) == (
+        "RDU", "stop", [{"key": "door", "value": "all"}])
+
+
+def test_tailgate_and_frunk_are_rdu_targets():
+    assert tc("RDU_2", "start", [{"key": "target", "value": "trunk"}]) == (
+        "RDU", "stop", [{"key": "target", "value": "trunk"}])
+    assert tc("RDU_2", "start", [{"key": "target", "value": "hood"}]) == (
+        "RDU", "start", [{"key": "target", "value": "hood"}])
+
+
+def test_an_uncaptured_rdu_target_is_refused():
+    assert tc("RDU_2", "start", [{"key": "target", "value": "sunroof"}]) is None


### PR DESCRIPTION
Rebased: this PR is now **only the lock/unlock command mapping**, stacked on #60 (the remaining remote commands). Everything else that used to be here — find, windows, climate, seat/wheel heat, air-clean, and now rapid warm/cool — moved to #60, which needs no second-owner confirmation and can land on its own.

What's left here is the single-source part you've rightly held: the door **lock / unlock / tailgate / frunk** directions on RDU/RDL. Directions verified against the car's own `centralLockingStatus`, not the service names — RDU+stop **unlocks**, RDL+start **locks**, and mapped the wrong way `lock.lock` silently opens the car. That's the failure mode that makes one capture insufficient; it waits on a second new-platform owner confirming the cycle.

The only commit here now is `9ec38cc`. Diff shows #60's commits too until that lands (same stacking as before).
