### PR TITLE
Car Reported At reads unknown on every new-platform car

### DIFF
--- a/custom_components/geely_connect/zeekr_adapter.py
+++ b/custom_components/geely_connect/zeekr_adapter.py
@@ -52,7 +52,7 @@ def _wrap_vehicle_status(data: Any) -> Any:
     """Give the new gateway's status payload the old platform's nesting.
 
     Old platform:  data = {"vehicleStatus": {basicVehicleStatus,
-                            additionalVehicleStatus}, "updateTime": ...}
+                            additionalVehicleStatus, "updateTime": ...}}
     New gateway:   data = {basicVehicleStatus, additionalVehicleStatus,
                             "updateTime": ...}
 
@@ -67,9 +67,16 @@ def _wrap_vehicle_status(data: Any) -> Any:
     if "basicVehicleStatus" not in data and "additionalVehicleStatus" not in data:
         return data
     wrapped = dict(data)
+    # `updateTime` belongs inside the wrapper too. It is the CAR's own stamp on
+    # the snapshot - as opposed to our poll clock - the old platform nests it
+    # there, and `Car Reported At` reads it from there. Left only at the top
+    # level it resolved to nothing, so that sensor read unknown on every
+    # new-platform car, silently disabling the one entity whose whole purpose
+    # (#24) is to reveal that a parked car has stopped reporting and the cloud
+    # is replaying an old snapshot.
     wrapped["vehicleStatus"] = {
         k: v for k, v in data.items()
-        if k in ("basicVehicleStatus", "additionalVehicleStatus")
+        if k in ("basicVehicleStatus", "additionalVehicleStatus", "updateTime")
     }
     return wrapped
 

--- a/tests/test_zeekr_new_platform.py
+++ b/tests/test_zeekr_new_platform.py
@@ -138,6 +138,16 @@ def test_wrapper_restores_the_old_platform_nesting():
     assert wrapped["updateTime"] == 1787817174561
 
 
+def test_the_cars_own_clock_lands_where_car_reported_at_reads_it():
+    """`updateTime` is the CAR's stamp on the snapshot, and the old platform
+    nests it inside vehicleStatus - which is where sensor._reported_at looks.
+    Left only at the top level it resolved to nothing, so `Car Reported At`
+    read unknown on every new-platform car: the one entity whose purpose is to
+    show that the cloud is replaying a stale snapshot (#24)."""
+    wrapped = adapter._wrap_vehicle_status(_STATUS_DATA)
+    assert wrapped["vehicleStatus"]["updateTime"] == 1787817174561
+
+
 def test_wrapper_leaves_everything_else_alone():
     old_shape = {"vehicleStatus": {"basicVehicleStatus": {}}, "updateTime": 1}
     assert adapter._wrap_vehicle_status(old_shape) is old_shape


### PR DESCRIPTION
`Car Reported At` reads `unknown` on every vehicle on the new platform, and it is the sensor whose whole job is to say the payload has stopped moving.

`updateTime` is the car's own stamp on the snapshot. The old platform nests it inside `vehicleStatus`, which is where `sensor._reported_at` walks for it; the new gateway sends it at the top level and `_wrap_vehicle_status` left it there. The walk finds nothing, so the sensor is blank — while `Last Updated` keeps advancing beside it, because that one is our clock and the polls are succeeding.

**How it surfaced.** The owner on #53 asked why his car still showed as at home. It had left at 07:20 and parked 18 km away at 07:50; at 09:29 the tracker still read `home`, and nothing anywhere in Home Assistant said the data was old. `Car Reported At` would have read 08:06 all morning. That is #24's scenario exactly — a parked Geely stops reporting, the cloud keeps serving the last snapshot, and a poll every ninety seconds republishes it — with the one entity that reveals it switched off.

**The fix** is one key added to the wrapper's list. I have deliberately kept it to that: whether these blocks should be *moved* rather than copied is a separate question with a different blast radius, and it is on #55 — this wants to be cherry-pickable without it.

Verified against a real new-platform car, and the underlying cause of the stale position is separate and not fixed here: `request_position_refresh` is a no-op on that platform, so nothing ever asks the car for a fresh fix. Opening the phone app refreshes it, and a forced poll then reads the correct location — so the decode and the tracker are fine, only the trigger is missing. That is a capture job and I will raise it separately.

Suite: 783 passed, 0 failed, 81 skipped (playwright). Coverage totals are identical to `main`'s in my environment — `4499 stmts / 17 miss` on both — so this adds no uncovered statement.
