### PR TITLE
feat(zeekr): derive x-vin for new-platform vehicles

### DIFF
--- a/custom_components/geely_connect/__init__.py
+++ b/custom_components/geely_connect/__init__.py
@@ -53,6 +53,7 @@ from .const import (
     CONF_ZEEKR_ENC_VIN,
     CONF_ZEEKR_HF_EXPIRY,
     CONF_ZEEKR_HF_TOKEN,
+    CONF_ZEEKR_NEW_PLATFORM,
     CONF_ZEEKR_PASSWORD,
     CONF_ZEEKR_REFRESH_TOKEN,
     DEFAULT_COUNTRY_CODE,
@@ -393,6 +394,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # what Home Assistant now warns about.
         zeekr_password = await hass.async_add_executor_job(
             password_decrypt, hass, d.get(CONF_ZEEKR_PASSWORD) or "")
+        configured_enc_vin = (
+            entry.options.get(CONF_ZEEKR_ENC_VIN)
+            if CONF_ZEEKR_ENC_VIN in entry.options
+            else d.get(CONF_ZEEKR_ENC_VIN)
+        ) or ""
         api = ZeekrAdapter(
             email=d.get(CONF_EMAIL) or "",
             vin=d[CONF_VIN],
@@ -409,9 +415,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             timezone=hass.config.time_zone or "UTC",
             hf_expiry=int(d.get(CONF_ZEEKR_HF_EXPIRY) or 0),
             # Options win over entry data so the token can be pasted or
-            # corrected from Configure without re-adding the integration.
-            enc_vin=(entry.options.get(CONF_ZEEKR_ENC_VIN)
-                     or d.get(CONF_ZEEKR_ENC_VIN) or ""),
+            # corrected from Configure without re-adding the integration. An
+            # explicitly blank option clears a stale data-level override.
+            enc_vin=configured_enc_vin,
+            new_platform_vehicle=bool(d.get(CONF_ZEEKR_NEW_PLATFORM, False)),
         )
     else:
         # Entries created before regions were tracked carry no CONF_REGION and

--- a/custom_components/geely_connect/api.py
+++ b/custom_components/geely_connect/api.py
@@ -130,7 +130,7 @@ _SECRET_KEYS: set = {
     # With a live session it both addresses AND controls the car, so it is a
     # capability secret, not just an identifier - redacted like the tokens
     # above. Normalised form, matched by both passes; see diagnostics._REDACT.
-    "zeekrencvin",
+    "zeekrencvin", "xvin", "encvin",
     # The IDaaS user-center session token as it appears on the wire (the new
     # platform's login responses carry it as `tokenValue`). No path folds a
     # successful login body into a log today, but masking it is a cheap hedge -

--- a/custom_components/geely_connect/config_flow.py
+++ b/custom_components/geely_connect/config_flow.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_ZEEKR_ENC_VIN,
     CONF_ZEEKR_HF_EXPIRY,
     CONF_ZEEKR_HF_TOKEN,
+    CONF_ZEEKR_NEW_PLATFORM,
     CONF_ZEEKR_PASSWORD,
     CONF_ZEEKR_REFRESH_TOKEN,
     CONF_STORE_PASSWORD,
@@ -165,6 +166,7 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._platform_default: str | None = None
         self._zeekr_hf_token: str | None = None
         self._zeekr_password: str | None = None
+        self._zeekr_new_platform = False
         # Set when this flow is a re-auth. We update the existing entry's
         # token instead of creating a new one in that case.
         self._reauth_entry: config_entries.ConfigEntry | None = None
@@ -530,6 +532,7 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     _LOGGER.error("zeekr login returned a malformed user_id; aborting")
                     errors["base"] = "unknown"
                 else:
+                    self._zeekr_new_platform = False
                     raw = await self.hass.async_add_executor_job(
                         client.list_vehicles, client.user_id)
                     if not raw:
@@ -539,6 +542,7 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         # cars today cannot reach this.
                         raw = await self.hass.async_add_executor_job(
                             client.list_vehicles_bff)
+                        self._zeekr_new_platform = bool(raw)
                         if raw:
                             _LOGGER.info(
                                 "garage found on the new-platform "
@@ -623,6 +627,7 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="reauth_account_mismatch")
             new_data = dict(entry.data)
             new_data[CONF_PLATFORM] = PLATFORM_ZEEKR
+            new_data[CONF_ZEEKR_NEW_PLATFORM] = self._zeekr_new_platform
             new_data[CONF_ZEEKR_ACCESS_TOKEN] = tokens[0]
             new_data[CONF_ZEEKR_REFRESH_TOKEN] = tokens[1]
             new_data[CONF_ZEEKR_HF_TOKEN] = self._zeekr_hf_token or ""
@@ -664,6 +669,7 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             title=title,
             data={
                 CONF_PLATFORM:            PLATFORM_ZEEKR,
+                CONF_ZEEKR_NEW_PLATFORM:  self._zeekr_new_platform,
                 CONF_EMAIL:               self._email,
                 CONF_COUNTRY_CODE:        self._country_code,
                 CONF_VIN:                 vin,
@@ -735,11 +741,10 @@ class GeelyIntlOptionsFlow(config_entries.OptionsFlow):
                 _apply_pressure_unit(self.hass, entry, new_unit)
             return self.async_create_entry(title="", data=user_input)
 
-        # New-platform vehicles are addressed by an opaque per-vehicle
-        # token rather than the plain VIN, and it cannot be derived from
-        # anything stored here. Offered only where it applies, and only as
-        # an optional field: without it the entry behaves exactly as
-        # before, reading status from the old platform.
+        # New-platform vehicles are addressed by an x-vin token rather than the
+        # plain VIN. BFF-discovered vehicles derive it automatically; the
+        # optional field remains available for app-version changes or an
+        # explicitly supplied value.
         extra: dict[Any, Any] = {}
         if current.get(CONF_PLATFORM, DEFAULT_PLATFORM) == PLATFORM_ZEEKR:
             extra[vol.Optional(

--- a/custom_components/geely_connect/const.py
+++ b/custom_components/geely_connect/const.py
@@ -94,9 +94,10 @@ CONF_ZEEKR_HF_TOKEN     = "zeekr_hf_token"
 CONF_ZEEKR_HF_EXPIRY    = "zeekr_hf_expiry"
 # The new platform addresses a vehicle by an opaque per-vehicle token in
 # the `x-vin` header rather than by the plain VIN. It is stable per car but
-# derived inside the app, so it is supplied by the owner rather than
-# computed; empty means "stay on the old-platform status path".
+# derived inside the app, so an explicit override remains supported for
+# compatibility; new-platform garage discovery can derive it automatically.
 CONF_ZEEKR_ENC_VIN      = "zeekr_enc_vin"
+CONF_ZEEKR_NEW_PLATFORM = "zeekr_new_platform"
 CONF_ZEEKR_PASSWORD     = "zeekr_password"
 CONF_STORE_PASSWORD     = "store_password"
 

--- a/custom_components/geely_connect/diagnostics.py
+++ b/custom_components/geely_connect/diagnostics.py
@@ -38,10 +38,10 @@ _REDACT = {
     # single point that has to be right. `zeekr_hf_expiry` is a timestamp and
     # stays visible on purpose.
     "zeekr_access_token", "zeekr_refresh_token", "zeekr_hf_token", "zeekr_password",
-    # The new platform's per-vehicle x-vin token - a capability secret that
+    # The new platform's per-vehicle x-vin token is a capability secret that
     # addresses and controls the car. redact() (the first pass) already masks
     # it by normalised name; this is the belt to that pass's braces.
-    "zeekr_enc_vin",
+    "zeekr_enc_vin", "x-vin", "x_vin", "enc_vin",
 }
 
 

--- a/custom_components/geely_connect/zeekr_adapter.py
+++ b/custom_components/geely_connect/zeekr_adapter.py
@@ -35,6 +35,7 @@ from typing import Any
 from .api import GeelyAuthError, GeelyControlError
 from .zeekr_client import (
     GATEWAY, ZeekrApiError, ZeekrAuthError, ZeekrClient, ZeekrIdaas,
+    derive_x_vin,
 )
 
 _AUTH_HINTS = (
@@ -91,7 +92,8 @@ class ZeekrAdapter:
                  hf_token: str = "", vehicle_model: str = "",
                  password: str = "", country_code: str = "AU",
                  timezone: str = "UTC", hf_expiry: int = 0,
-                 gateway: str = GATEWAY, enc_vin: str = "") -> None:
+                 gateway: str = GATEWAY, new_platform_vehicle: bool = False,
+                 enc_vin: str = "") -> None:
         self.vin = vin
         self.user_id = user_id
         self._email = email
@@ -108,8 +110,11 @@ class ZeekrAdapter:
         self._client.user_id = user_id
         self._client.hf_token = hf_token or None
         # Set only for vehicles that live on the new platform; selects the
-        # new-gateway status path in vehicle_status() below.
-        self._client.enc_vin = enc_vin or ""
+        # new-gateway status path in vehicle_status() below. An explicit value
+        # remains an override for future app-version changes.
+        self._client.enc_vin = enc_vin or (
+            derive_x_vin(vin) if new_platform_vehicle else ""
+        )
         # Set when a silent HF renewal happened; the coordinator persists the
         # new token + expiry into the config entry after the next poll.
         self.hf_dirty = False

--- a/custom_components/geely_connect/zeekr_client.py
+++ b/custom_components/geely_connect/zeekr_client.py
@@ -254,6 +254,36 @@ def _safe_detail(raw: bytes | str, limit: int = 200) -> str:
         return "<non-JSON body omitted>"
 
 
+# Package-level material used by the Geely EM 1.1.0 app's local VIN transform.
+# These are protocol constants, not account credentials; retain the app version
+# here because a future app release may rotate or change the transform.
+_X_VIN_APP_VERSION = "1.1.0"
+_X_VIN_KEY = b"a01a6db985a2f5d4"
+_X_VIN_IV = b"ed446b8b8845013d"
+
+
+def derive_x_vin(vin: str) -> str:
+    """Return the app-compatible ``x-vin`` header for an ordinary VIN.
+
+    The Geely EM app stores the ordinary VIN and applies AES-128-CBC with
+    PKCS#5/PKCS#7 padding, then standard Base64 without line wrapping. The
+    package material is versioned above and is not tied to a user's account.
+    """
+    if not isinstance(vin, str) or not vin:
+        raise ValueError("VIN must be a non-empty string")
+    try:
+        from Crypto.Cipher import AES
+        from Crypto.Util.Padding import pad
+    except ImportError as exc:  # pragma: no cover - dependency is in manifest
+        raise ZeekrApiError(
+            "pycryptodome is required for x-vin derivation"
+        ) from exc
+    cipher = AES.new(_X_VIN_KEY, AES.MODE_CBC, iv=_X_VIN_IV)
+    padded = pad(vin.encode("utf-8"), AES.block_size)
+    encrypted = cipher.encrypt(padded)
+    return base64.b64encode(encrypted).decode("ascii")
+
+
 def _make_nonce() -> str:
     """Mirror the app's nonce shape: 3hex-12hex 7alnum 13ts (cosmetic, unique)."""
     prefix = "".join(random.choices(_NONCE_HEX, k=3))

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -53,10 +53,11 @@ def test_zeekr_platform_secrets_are_masked_but_the_expiry_stays_readable():
         # The per-vehicle x-vin token: with a session it addresses AND controls
         # the car, so it is a capability secret and must be masked like the rest.
         "zeekr_enc_vin": "b2FzZGtqYXNkb2lqYXNkb2lqYXNkMTIzNDU2Nzg=",
+        "x-vin": "b2FzZGtqYXNkb2lqYXNkb2lqYXNkMTIzNDU2Nzg=",
         "zeekr_hf_expiry": 1786000000, "platform": "zeekr",
     })
     for k in ("zeekr_access_token", "zeekr_refresh_token", "zeekr_hf_token",
-              "zeekr_password", "zeekr_enc_vin"):
+              "zeekr_password", "zeekr_enc_vin", "x-vin"):
         assert out[k] == "***redacted***", f"{k} survived as {out[k]!r}"
     assert TOKEN not in json.dumps(out)
     assert "b2FzZGtq" not in json.dumps(out), "the x-vin token leaked"

--- a/tests/test_zeekr_adapter.py
+++ b/tests/test_zeekr_adapter.py
@@ -27,14 +27,17 @@ class _StubIdaas:
 
 
 def _make_adapter(password: str = "", hf_token: str = "mock-hf",
-                  hf_expiry: int = 10 ** 15) -> ad.ZeekrAdapter:
+                  hf_expiry: int = 10 ** 15,
+                  new_platform_vehicle: bool = False,
+                  enc_vin: str = "") -> ad.ZeekrAdapter:
     """Adapter with a stubbed client surface; returns (adapter, client)."""
     a = ad.ZeekrAdapter(
         email="user@example.com", vin=FAKE_VIN, user_id="mock-uid",
         access_token="mock-at", refresh_token="mock-rt",
         hf_token=hf_token, vehicle_model="E245-J1",
         password=password, country_code="AU", timezone="UTC",
-        hf_expiry=hf_expiry, gateway="https://unused.invalid")
+        hf_expiry=hf_expiry, gateway="https://unused.invalid",
+        new_platform_vehicle=new_platform_vehicle, enc_vin=enc_vin)
     c = a._client
     c.hf_token = hf_token or None
     c.vehicle_status_resp = lambda vin, user_id=None: {
@@ -302,3 +305,20 @@ def test_a_vehicle_with_the_new_token_reads_the_new_gateway():
     st = a.vehicle_status()
     assert st["code"] == 1000, "000000 was not translated"
     assert st["data"]["vehicleStatus"]["basicVehicleStatus"]["powerLevel"] == 55, st
+
+
+def test_new_platform_marker_derives_x_vin_from_the_ordinary_vin():
+    a, c = _make_adapter(new_platform_vehicle=True)
+    assert c.enc_vin == zc.derive_x_vin(FAKE_VIN)
+
+
+def test_explicit_x_vin_override_wins_over_derivation():
+    supplied = "owner-supplied-fake-x-vin"
+    _, c = _make_adapter(new_platform_vehicle=True, enc_vin=supplied)
+    assert c.enc_vin == supplied
+
+
+def test_explicit_x_vin_override_is_used_without_the_source_marker():
+    supplied = "owner-supplied-fake-x-vin"
+    _, c = _make_adapter(new_platform_vehicle=False, enc_vin=supplied)
+    assert c.enc_vin == supplied

--- a/tests/test_zeekr_client.py
+++ b/tests/test_zeekr_client.py
@@ -25,7 +25,8 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
-from conftest import FAKE_VIN, load
+from conftest import FAKE_VIN, have_homeassistant, load
+from run import skip
 
 zc = load("zeekr_client")
 
@@ -925,3 +926,39 @@ def test_derive_x_vin_rejects_an_empty_vin():
         assert False, "empty VIN must be rejected before encryption"
     except ValueError as exc:
         assert str(exc) == "VIN must be a non-empty string"
+
+
+def test_bff_garage_handles_nested_lists_and_missing_vehicle_data():
+    c = zc.ZeekrClient("user@example.com", "pw", gateway="https://unused.invalid")
+    c.access_token = "mock-at"
+    c._request = lambda *args, **kwargs: {"data": {"records": [{"vin": FAKE_VIN}]}}
+    assert c.list_vehicles_bff() == [{"vin": FAKE_VIN}]
+    c._request = lambda *args, **kwargs: {"data": {}}
+    assert c.list_vehicles_bff() == []
+
+
+def test_new_gateway_guards_require_access_token_and_x_vin():
+    c = zc.ZeekrClient("user@example.com", "pw", gateway="https://unused.invalid")
+    try:
+        c.list_vehicles_bff()
+        assert False, "BFF garage must require the new-platform token"
+    except zc.ZeekrAuthError:
+        pass
+    c.access_token = "mock-at"
+    try:
+        c.vehicle_status_new_resp()
+        assert False, "new-platform status must require x-vin"
+    except zc.ZeekrAuthError:
+        pass
+    c2 = zc.ZeekrClient("user@example.com", "pw", gateway="https://unused.invalid")
+    try:
+        c2.vehicle_status_new_resp()
+        assert False, "new-platform status must require access token"
+    except zc.ZeekrAuthError:
+        pass
+
+
+def test_speed_staleness_rejects_non_dict_input():
+    if not have_homeassistant():
+        skip("homeassistant not installed")
+    assert load("helpers").speed_is_stale(None) is False

--- a/tests/test_zeekr_client.py
+++ b/tests/test_zeekr_client.py
@@ -911,3 +911,17 @@ def test_vehicle_record_helpers_tail_branches():
     assert zc.vehicle_vin({"vin": ""}) is None
     assert zc.vehicle_nickname({}) == ""
     assert zc.vehicle_nickname({"nickname": 0}) == ""
+
+
+def test_derive_x_vin_uses_the_fake_vin_vector():
+    assert zc.derive_x_vin(FAKE_VIN) == (
+        "WiKxSxxI5XwF/OLDvgdzNabt3Iz963eR5dFKNGObuG8="
+    )
+
+
+def test_derive_x_vin_rejects_an_empty_vin():
+    try:
+        zc.derive_x_vin("")
+        assert False, "empty VIN must be rejected before encryption"
+    except ValueError as exc:
+        assert str(exc) == "VIN must be a non-empty string"

--- a/tests/test_zeekr_config_flow.py
+++ b/tests/test_zeekr_config_flow.py
@@ -420,3 +420,27 @@ def test_reconfigure_choosing_legacy_goes_to_the_legacy_form():
     flow.hass.config_entries.async_get_entry = lambda eid: entry
     res = asyncio.run(flow.async_step_reconfigure({"platform": "legacy"}))
     assert res["type"] == "form" and res["step_id"] == "user", res
+
+
+def test_zeekr_options_show_and_normalize_x_vin():
+    cf, flow = _flow()
+    entry = type("_Entry", (), {
+        "entry_id": "e1",
+        "data": {"platform": "zeekr", "poll_mode": "normal",
+                 "pressure_unit": "psi", "full_exposure": False,
+                 "zeekr_enc_vin": "old-value"},
+        "options": {},
+    })()
+    opts = cf.GeelyIntlOptionsFlow()
+    opts.handler = entry.entry_id
+    flow.hass.config_entries.async_get_known_entry = lambda _id: entry
+    opts.hass = flow.hass
+    opts.async_show_form = flow.async_show_form
+    opts.async_create_entry = flow.async_create_entry
+    form = asyncio.run(opts.async_step_init(None))
+    assert any(str(key) == "zeekr_enc_vin" for key in form["data_schema"].schema)
+    result = asyncio.run(opts.async_step_init({
+        "poll_mode": "normal", "pressure_unit": "psi",
+        "full_exposure": False, "zeekr_enc_vin": "  fake-override  ",
+    }))
+    assert result["data"]["zeekr_enc_vin"] == "fake-override"

--- a/tests/test_zeekr_config_flow.py
+++ b/tests/test_zeekr_config_flow.py
@@ -153,6 +153,7 @@ def test_zeekr_login_creates_a_stamped_entry_without_storing_the_password():
     assert data["zeekr_access_token"] == "mock-at"
     assert data["zeekr_hf_token"] == "mock-hf"
     assert data["zeekr_password"] == "", "store_password=False must not store it"
+    assert data["zeekr_new_platform"] is False
 
 
 def test_zeekr_login_stores_the_password_when_consented():
@@ -208,6 +209,7 @@ def test_a_migrated_account_is_found_on_the_new_platform_garage():
     res = asyncio.run(flow.async_step_zeekr_login(_zeekr_login_input()))
     assert res["type"] == "create_entry", res
     assert res["data"]["vin"] == FAKE_VIN
+    assert res["data"]["zeekr_new_platform"] is True
 
 
 def test_zeekr_login_with_multiple_vehicles_picks_one():

--- a/tests/test_zeekr_init.py
+++ b/tests/test_zeekr_init.py
@@ -210,3 +210,43 @@ def test_a_blank_x_vin_option_clears_a_stale_data_override():
     assert ok is True
     assert api.kw["enc_vin"] == ""
     assert api.kw["new_platform_vehicle"] is True
+
+
+def test_the_optimistic_switch_writes_state_when_attached():
+    if not have_homeassistant():
+        skip("homeassistant not installed")
+    sw = load("switch")
+    entity = sw._OptimisticHold()
+    writes = []
+    entity.hass = object()
+    entity.async_write_ha_state = lambda: writes.append(True)
+    entity._write_held_state()
+    assert writes == [True]
+
+
+def test_rapid_silence_notification_is_best_effort():
+    if not have_homeassistant():
+        skip("homeassistant not installed")
+    climate = load("climate")
+    from homeassistant.components import persistent_notification
+
+    entity = climate.GeelyClimate.__new__(climate.GeelyClimate)
+    entity._hass = object()
+    entity._vin = FAKE_VIN
+    calls = []
+    original = persistent_notification.async_create
+    persistent_notification.async_create = lambda *args, **kwargs: calls.append((args, kwargs))
+    try:
+        entity._notify_rapid_silence("cooling")
+    finally:
+        persistent_notification.async_create = original
+    assert calls and calls[0][1]["title"] == "Geely: rapid command not confirmed"
+
+    def fail_notification(*args, **kwargs):
+        raise RuntimeError("notification unavailable")
+
+    persistent_notification.async_create = fail_notification
+    try:
+        entity._notify_rapid_silence("warming")
+    finally:
+        persistent_notification.async_create = original

--- a/tests/test_zeekr_init.py
+++ b/tests/test_zeekr_init.py
@@ -67,6 +67,7 @@ def _zeekr_entry():
             "vehicle_nickname": "My EX5", "vehicle_series": "E245-J1",
             "vehicle_model_code": "E245-J1", "vehicle_color": "White",
             "vehicle_power_type": "BEV",
+            "zeekr_new_platform": True,
             "pressure_unit": "kPa", "poll_mode": "normal",
         },
         options={},
@@ -173,6 +174,7 @@ def test_zeekr_entry_builds_the_adapter_with_its_tokens():
     assert kw["timezone"] == "Europe/Berlin", \
         "the HA time zone must drive the HF timezone header"
     assert kw["vehicle_model"] == "E245-J1"
+    assert kw["new_platform_vehicle"] is True
 
 
 def test_zeekr_hf_renewal_is_persisted_into_the_entry():
@@ -197,3 +199,13 @@ def test_zeekr_hf_renewal_is_persisted_into_the_entry():
     n = len(hass.config_entries.updates)
     asyncio.run(_FakeCoordinator.instance.refresh())
     assert len(hass.config_entries.updates) == n, "spurious entry update"
+
+
+def test_a_blank_x_vin_option_clears_a_stale_data_override():
+    m = _mod()
+    entry = _zeekr_entry()
+    entry.data["zeekr_enc_vin"] = "stale-owner-supplied-value"
+    entry.options = {"zeekr_enc_vin": ""}
+    ok, _, _, api = _setup_zeekr(m, entry=entry)
+    assert ok is True
+    assert api.kw["enc_vin"] == ""

--- a/tests/test_zeekr_init.py
+++ b/tests/test_zeekr_init.py
@@ -209,3 +209,4 @@ def test_a_blank_x_vin_option_clears_a_stale_data_override():
     ok, _, _, api = _setup_zeekr(m, entry=entry)
     assert ok is True
     assert api.kw["enc_vin"] == ""
+    assert api.kw["new_platform_vehicle"] is True


### PR DESCRIPTION
## Summary

The new Geely EM platform's status endpoint requires an `x-vin` header. The current integration accepts that value as an advanced, owner-supplied option, but the official app derives it locally from the ordinary vehicle VIN.

This PR derives the header value automatically for vehicles discovered through the new-platform garage path. It leaves the existing manual override in place for compatibility and future app-version changes.

## What the app does

The app's vehicle-request interceptor applies this transform:

    ordinary VIN
      -> AES-128-CBC with PKCS#5/PKCS#7 padding
      -> standard Base64 without line wrapping
      -> X-VIN header

The package-level AES material is not an account credential or session token. It is already publicly documented by the independent MIT-licensed `Wysie/zeekr_key_extractor` project and its public issue history. This change does not bypass login, replace the access token, reproduce app attestation, or change TLS validation.

## Behaviour

- A vehicle found through the new `ms-app-bff` garage fallback automatically gets a derived `x-vin` value.
- Vehicles that remain on the existing HF/Ecarx garage continue using the existing old-platform status path; they do not get routed to the new gateway merely because they use the Zeekr platform login.
- An explicitly configured `zeekr_enc_vin` override continues to take precedence, allowing recovery if the app changes its package material.
- Generated and supplied `x-vin` values are excluded from logs and diagnostics.
- No account credentials, real VINs, captured requests, or live vehicle data are added to the repository.

## Testing

- Adds an offline unit vector using an obviously fake VIN only.
- Verifies the expected Base64 output and padding behaviour.
- Verifies that the new-gateway request receives `x-vin` and that the existing old-platform path remains unchanged when the new-platform source marker is absent.
- Runs the existing standalone test suite and static compilation checks.
- No real authentication call or live vehicle/API validation is part of this change.

## Limitations

The AES material is package/version material and may change in a future app release. The explicit override is retained for that reason. A future update that changes the transform should update the versioned constants and the fake vector rather than exposing any user or account data.

## References

- https://github.com/Wysie/zeekr_key_extractor
- https://github.com/Wysie/zeekr_key_extractor/issues/10
- https://github.com/YossiKon/geely-connect/issues/53
- https://github.com/YossiKon/geely-connect/releases/tag/v1.46.0
