### PR TITLE
New platform: capability catalogue and the read entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ polished setup on top.
 ## ✨ Highlights
 
 - 🔒 **Security-first** - verified TLS plus public-key pinning.
-- 📊 **Everything enabled** - all 76 entities are on from the start (89 on a
+- 📊 **Everything enabled** - all 83 entities are on from the start (96 on a
   hybrid), no duplicates, nothing to switch on by hand.
 - 🧮 **Computed extras** - charging power, charge completion time, range at full
   charge and efficiency, none of which the car reports itself.
@@ -1057,10 +1057,15 @@ per-trim pack sizes.
 **Everything is on from the start** - nothing is hidden and nothing needs
 enabling. Everything the car reports, plus the computed extras above.
 
-The one thing that varies by car is propulsion: the thirteen fuel and engine
+The main thing that varies by car is propulsion: the thirteen fuel and engine
 entities are created only for a car with a tank, so a battery-electric EX5 gets
-76 entities and a PHEV gets 89. That's a decision made once at startup from your
+83 entities and a PHEV gets 96. That's a decision made once at startup from your
 account's `powerType` plus the car's own telemetry - there is no option to set.
+
+Two more - `Charging (reported)` and `Plugged In (reported)` - are built only for
+a car read through the new Geely EM platform, because the old platform's payload
+does not carry those two fields at all. A car on the new platform therefore gets
+85, or 98 with a tank.
 
 The only thing not created is the raw full-exposure pass (see below), because
 those are duplicates of the curated entities by definition. Two aggregates that

--- a/custom_components/geely_connect/binary_sensor.py
+++ b/custom_components/geely_connect/binary_sensor.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import CONF_ZEEKR_ENC_VIN, DOMAIN
 from .helpers import walk as _walk
 
 _SAFE = ("vehicleStatus", "additionalVehicleStatus", "drivingSafetyStatus")
@@ -129,6 +129,7 @@ SPECS: tuple[tuple[str, str, tuple[str, ...], BinarySensorDeviceClass | None, tu
     # field is the one that never reaches 3 on a DC fast charge (#10), so a
     # plain bool from the same payload is worth having next to it - and being
     # a JSON boolean there is nothing to decode and no code set to enumerate.
+    # New-platform only - see _NEW_PLATFORM_ONLY.
     ("is_charging",          "Charging (reported)", (*_EV, "isCharging"),                    BinarySensorDeviceClass.BATTERY_CHARGING, (True, "true", "True")),
     ("is_plugged_in",        "Plugged In (reported)", (*_EV, "isPluggedIn"),                 BinarySensorDeviceClass.PLUG,    (True, "true", "True")),
     # Park brake, on/off beside the mapped text sensor that names the code -
@@ -186,6 +187,18 @@ HYBRID_SPECS: tuple[tuple[str, str, tuple[str, ...], BinarySensorDeviceClass | N
 )
 
 
+# Built only for a car whose status comes from the new platform. A real
+# old-platform payload carries neither field, so on an old-platform car these
+# two could only ever read unknown - a tile that never says anything is worse
+# than no tile.
+#
+# The gate is the x-vin token rather than the entry's platform, because the
+# token is what decides which status endpoint is read: a zeekr entry without
+# one still polls the legacy path and gets the legacy fields
+# (ZeekrAdapter.vehicle_status). Everything else added alongside these two -
+# the four door locks, the second trip meter, the discharge pair - is in both
+# platforms' payloads and is deliberately NOT gated.
+_NEW_PLATFORM_ONLY = frozenset({"is_charging", "is_plugged_in"})
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, add_entities: AddEntitiesCallback) -> None:
@@ -196,10 +209,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, add_entitie
     verdict = bundle.get("propulsion")
     specs = SPECS + (HYBRID_SPECS if verdict and verdict.has_tank else ())
     charges = verdict.charges if verdict else True
+    # Options win over entry data, the same way __init__ builds the adapter,
+    # so a token pasted into Configure takes effect on reload.
+    new_platform = bool(entry.options.get(CONF_ZEEKR_ENC_VIN)
+                        or entry.data.get(CONF_ZEEKR_ENC_VIN))
     entities: list[BinarySensorEntity] = [
         GeelyBinarySensor(coordinator, vin, device_name, *s) for s in specs
         # No socket, no plug sensor - see Verdict.charges.
-        if charges or s[0] != "charger_plugged_in"
+        if (charges or s[0] != "charger_plugged_in")
+        # No x-vin token, no new-platform payload - see _NEW_PLATFORM_ONLY.
+        and (new_platform or s[0] not in _NEW_PLATFORM_ONLY)
     ]
     # Connectivity: is the integration currently reaching the car's cloud?
     entities.append(GeelyConnectivity(coordinator, vin, device_name))

--- a/custom_components/geely_connect/binary_sensor.py
+++ b/custom_components/geely_connect/binary_sensor.py
@@ -109,6 +109,28 @@ SPECS: tuple[tuple[str, str, tuple[str, ...], BinarySensorDeviceClass | None, tu
     # 0 unlocked. So 0 is the unlocked code here too, which with device_class
     # LOCK is what "on" has to mean.
     ("trunk_unlocked",       "Trunk Lock",        (*_SAFE, "trunkLockStatus"),              BinarySensorDeviceClass.LOCK,    ("0", 0)),
+    # The four individual door locks, on exactly the footing trunkLockStatus
+    # was added on. In a capture across a real lock/unlock cycle all four moved
+    # with `centralLockingStatus` and with each other - 1/1/1/1 while the car
+    # was locked, 0/0/0/0 while it was not - so 0 is the unlocked code here
+    # too, which with device_class LOCK is what "on" has to mean.
+    #
+    # The aggregate lock entity says whether the car is locked; these say
+    # which door is not, which is the question after a "car unlocked" alert.
+    # In the same capture the tailgate command moved trunkLockStatus 1 -> 0 -> 1
+    # while all four of these stayed 1, so they are genuinely per-door and not
+    # four copies of one flag.
+    ("door_lock_driver",     "Door Lock Driver",    (*_SAFE, "doorLockStatusDriver"),        BinarySensorDeviceClass.LOCK,    ("0", 0)),
+    ("door_lock_passenger",  "Door Lock Passenger", (*_SAFE, "doorLockStatusPassenger"),     BinarySensorDeviceClass.LOCK,    ("0", 0)),
+    ("door_lock_rear_left",  "Door Lock Rear Left", (*_SAFE, "doorLockStatusDriverRear"),    BinarySensorDeviceClass.LOCK,    ("0", 0)),
+    ("door_lock_rear_right", "Door Lock Rear Right", (*_SAFE, "doorLockStatusPassengerRear"), BinarySensorDeviceClass.LOCK,   ("0", 0)),
+    # The car's own booleans for charging and plugged-in, beside the entities
+    # derived from `statusOfChargerConnection` rather than replacing them. That
+    # field is the one that never reaches 3 on a DC fast charge (#10), so a
+    # plain bool from the same payload is worth having next to it - and being
+    # a JSON boolean there is nothing to decode and no code set to enumerate.
+    ("is_charging",          "Charging (reported)", (*_EV, "isCharging"),                    BinarySensorDeviceClass.BATTERY_CHARGING, (True, "true", "True")),
+    ("is_plugged_in",        "Plugged In (reported)", (*_EV, "isPluggedIn"),                 BinarySensorDeviceClass.PLUG,    (True, "true", "True")),
     # Park brake, on/off beside the mapped text sensor that names the code -
     # the same pairing `statusOfChargerConnection` already has (Charger Plug
     # here, Charger Connection there), and for the same reason: an automation

--- a/custom_components/geely_connect/sensor.py
+++ b/custom_components/geely_connect/sensor.py
@@ -237,6 +237,15 @@ SENSOR_SPECS: tuple[tuple, ...] = (
     ("12v_voltage",         "12V Voltage",          (*_MAINT, "mainBatteryStatus", "voltage"),         UnitOfElectricPotential.VOLT,     SensorDeviceClass.VOLTAGE,     "float", None),
     ("avg_consumption",     "Average Consumption",  (*_EV,    "averPowerConsumption"),                 "kWh/100km",                      _ENERGY_DISTANCE,              "float", None),
     ("trip_meter",          "Trip Meter",           (*_RUN,   "tripMeter1"),                           UnitOfLength.KILOMETERS,          SensorDeviceClass.DISTANCE,    "float", None),
+    # The second trip meter, beside the first. Same object, same units - it
+    # read 167.4 against tripMeter1's own value on a real car, both plainly km.
+    ("trip_meter_2",        "Trip Meter 2",         (*_RUN,   "tripMeter2"),                           UnitOfLength.KILOMETERS,          SensorDeviceClass.DISTANCE,    "float", None),
+    # Vehicle-to-load. The discharge pair mirrors the charge pair exactly -
+    # same object, same names with disCharge for charge - so the units carry
+    # over without needing a decode. Both read 0.0 with nothing plugged in,
+    # which is the honest reading rather than an absent one.
+    ("discharge_current",   "Discharge Current",    (*_EV,    "disChargeIAct"),                        UnitOfElectricCurrent.AMPERE,     SensorDeviceClass.CURRENT,     "float", None),
+    ("discharge_voltage",   "Discharge Voltage",    (*_EV,    "disChargeUAct"),                        UnitOfElectricPotential.VOLT,     SensorDeviceClass.VOLTAGE,     "float", None),
     ("avg_speed",           "Average Speed",        (*_RUN,   "avgSpeed"),                             UnitOfSpeed.KILOMETERS_PER_HOUR,  SensorDeviceClass.SPEED,       "float", None),
     # Tyre temperatures, from the same TPMS sensors as the pressures below.
     # Present in every payload and read by nothing until now. Worth having on

--- a/custom_components/geely_connect/zeekr_adapter.py
+++ b/custom_components/geely_connect/zeekr_adapter.py
@@ -29,6 +29,7 @@ explicitly unimplemented until the primary path is proven live.
 # Scott Lorien (@scottaki) in pull request #33. See NOTICE.txt.
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any
 
@@ -36,6 +37,8 @@ from .api import GeelyAuthError, GeelyControlError
 from .zeekr_client import (
     GATEWAY, ZeekrApiError, ZeekrAuthError, ZeekrClient, ZeekrIdaas,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 _AUTH_HINTS = (
     "token", "auth", "login", "session", "expired", "unauthor",
@@ -46,6 +49,114 @@ _AUTH_HINTS = (
 def _looks_authy(text: str) -> bool:
     low = text.lower()
     return any(h in low for h in _AUTH_HINTS)
+
+
+# Capability codes on the new platform, mapped to the old catalogue's
+# functionIds. Every row is justified by the vendor's own `functionName` label
+# carried in the same payload, quoted here so the reasoning is checkable
+# rather than remembered.
+_CAPABILITY_CODES: dict[str, str] = {
+    # plainly-named codes the old catalogue also uses
+    "remote_control_lock_2":   "remote_control_lock_2",
+    "remote_control_unlock_2": "remote_control_unlock_2",
+    "remote_charge_2":         "remote_charge_2",
+    "honk_flash":              "honk_flash",
+    "parking_comfortable_2":   "parking_comfortable_2",
+    "remote_purification":     "remote_purification",
+    # service-shaped codes, read from their labels
+    "C_RDU_2_2": "remote_control_open_2",       # 远程解锁-控制设备_后备箱 (tailgate)
+    "C_RDU_2_3": "remote_control_unlock_2",     # 远程解锁-控制设备_车门 (doors)
+    "C_RWS_1":   "remote_control_ventilate_2",  # 远程车窗微开 (window vent)
+    "C_RWS_1_5": "remote_control_window_2",     # 远程车窗关闭 (windows)
+    "C_RHL_1":   "honk_flash",                  # 远程闪灯鸣笛
+    "C_RHL_2":   "honk_flash",                  # 单独闪灯
+    "C_RHL_3":   "honk_flash",                  # 单独鸣笛
+    # climate: several codes all mean "this car has remote climate"
+    "remote_climate_control": "remote_climate_control_2",  # ZK空调服务不区分命令
+    "C_PAA_1":  "remote_climate_control_2",     # 智能温控_PAA空调
+    "C_PAA_12": "remote_climate_control_2",     # 智能温控入口
+    "C_ZAF_1":  "remote_climate_control_2",     # 环境调节_空调远控指令
+}
+
+# Seat-heat positions, from the codes that name one seat each.
+_SEAT_HEAT_POSITIONS: dict[str, str] = {
+    "C_PAA_5_1": "front-left",    # …PAA座椅加热支持的位置_主驾
+    "C_PAA_5_2": "front-right",   # …PAA座椅加热支持的位置_副驾
+    "V_ZYJRZH_1_3": "front-left",   # 远程座椅加热转换-座椅位置_左前
+    "V_ZYJRZH_1_4": "front-right",  # 远程座椅加热转换-座椅位置_右前
+}
+
+_WHEEL_HEAT_CODE = "C_PAA_6"      # …PAA是否支持方向盘加热
+
+
+def _enabled_row(row: dict) -> bool:
+    """`paramValueUse` is the enable flag; "N"/"0"/blank mean not available."""
+    use = row.get("paramValueUse")
+    if use is None:
+        return False
+    text = str(use).strip()
+    return bool(text) and text.upper() not in ("N", "0", "FALSE", "NO")
+
+
+def translate_capabilities(rows: list[dict]) -> list[dict]:
+    """New-platform catalogue -> the entry shape capabilities.py parses.
+
+    The rule is deliberately asymmetric, because the two platforms describe a
+    car at different resolutions:
+
+      * a feature is ENABLED when a code for it is present, and
+      * absence means "not fitted" ONLY for the features this catalogue
+        actually enumerates.
+
+    The distinction matters. The catalogue lists seat-heat positions one code
+    per seat, so no seat-vent code is real evidence the car has none. But the
+    climate entry is labelled 空调服务不区分命令 - "the AC service does not
+    distinguish commands" - so it cannot say whether defrost exists, and
+    reading its silence as "no defrost" would remove a control that works.
+    Anything in that second class is left to the permissive default rather
+    than being switched off on absence.
+
+    An empty or unrecognised catalogue returns [] - the caller then keeps
+    today's all-features behaviour, so this can never be worse than before.
+    """
+    if not rows:
+        return []
+    live = {r.get("functionCode") for r in rows if _enabled_row(r)}
+    if not live:
+        return []
+
+    ids: set[str] = {_CAPABILITY_CODES[c] for c in live if c in _CAPABILITY_CODES}
+    entries: list[dict] = []
+
+    seats = sorted({pos for code, pos in _SEAT_HEAT_POSITIONS.items() if code in live})
+    if "remote_climate_control_2" in ids:
+        params = [
+            # The service is undifferentiated, so defrost and AC are asserted
+            # rather than discovered - see the docstring.
+            {"nameKey": "climate_devices", "config": "AC;defrost"},
+        ]
+        if seats:
+            params.append({"nameKey": "dpt_heat_loc", "config": ",".join(seats)})
+        if _WHEEL_HEAT_CODE in live:
+            params.append({"nameKey": "steel_wheel_heating", "config": "true"})
+        if "remote_control_ventilate_2" in ids:
+            params.append({"nameKey": "window_ventilation", "config": "true"})
+        entries.append({"functionId": "remote_climate_control_2",
+                        "valueEnable": True, "paramsJson": params})
+        ids.discard("remote_climate_control_2")
+
+    if "remote_control_unlock_2" in ids:
+        targets = ["door"]
+        if "C_RDU_2_2" in live:
+            targets.append("trunk")
+        if "C_RDU_2_1" in live:            # 前备箱 (frunk)
+            targets.append("hood")
+        entries.append({"functionId": "remote_control_unlock_2", "valueEnable": True,
+                        "paramsJson": [{"nameKey": "door", "config": ",".join(targets)}]})
+        ids.discard("remote_control_unlock_2")
+
+    entries.extend({"functionId": fid, "valueEnable": True} for fid in sorted(ids))
+    return entries
 
 
 def _wrap_vehicle_status(data: Any) -> Any:
@@ -245,10 +356,25 @@ class ZeekrAdapter:
         )
 
     def fetch_capabilities(self) -> list[dict]:
-        # Legacy /geelyTCAccess/tcservices/capability has a new-platform
-        # sibling but its shape is unverified; an empty catalog is the
-        # documented best-effort default (all-features view).
-        return []
+        """The catalogue, translated into the shape capabilities.py parses.
+
+        Only vehicles addressed by an x-vin token can be asked; everything
+        else keeps the previous behaviour of an empty catalogue, which
+        capabilities.py reads as the permissive all-features view. A failure
+        here is deliberately swallowed for the same reason: losing the
+        catalogue must cost a car its feature *filtering*, never its entities.
+        """
+        if not self._client.enc_vin:
+            return []
+        try:
+            rows = self._authed(self._client.capabilities_new)
+        except (ZeekrAuthError, ZeekrApiError, GeelyAuthError) as err:
+            _LOGGER.debug("new-platform capability fetch failed: %s", err)
+            return []
+        entries = translate_capabilities(rows or [])
+        _LOGGER.debug("new-platform capabilities: %d row(s) -> %d entry/entries",
+                      len(rows or []), len(entries))
+        return entries
 
     # ---- platform surface --------------------------------------------------
 

--- a/custom_components/geely_connect/zeekr_adapter.py
+++ b/custom_components/geely_connect/zeekr_adapter.py
@@ -75,11 +75,15 @@ def _wrap_vehicle_status(data: Any) -> Any:
         return data
     if "basicVehicleStatus" not in data and "additionalVehicleStatus" not in data:
         return data
-    wrapped = dict(data)
-    wrapped["vehicleStatus"] = {
-        k: v for k, v in data.items()
-        if k in ("basicVehicleStatus", "additionalVehicleStatus", "updateTime")
-    }
+    # MOVE the keys rather than copying them. A copy leaves a second path to
+    # every field - basicVehicleStatus.* as well as
+    # vehicleStatus.basicVehicleStatus.* - and the full-exposure sensor sweep
+    # skips only curated paths, which all start "vehicleStatus.". Every
+    # duplicate therefore becomes an extra raw diagnostic entity: roughly two
+    # hundred of them on this car, each a twin of one already on the list.
+    moved = ("basicVehicleStatus", "additionalVehicleStatus", "updateTime")
+    wrapped = {k: v for k, v in data.items() if k not in moved}
+    wrapped["vehicleStatus"] = {k: v for k, v in data.items() if k in moved}
     return wrapped
 
 

--- a/custom_components/geely_connect/zeekr_client.py
+++ b/custom_components/geely_connect/zeekr_client.py
@@ -908,6 +908,29 @@ class ZeekrClient:
                     return [v for v in val if isinstance(v, dict)]
         return []
 
+    def capabilities_new(self) -> list[dict]:
+        """The new platform's capability catalogue for this vehicle.
+
+        GET /ms-vehicle-capability/api/v1.0/vehicle/function/model/info with no
+        query at all - the vehicle comes from the x-vin header. Rows look like
+
+            {"functionCategory": "remote_control",
+             "functionCode": "C_RDU_2_2", "functionName": "远程解锁-控制设备_后备箱",
+             "paramCode": null, "paramValueUse": "Y", ...}
+
+        Returned raw; zeekr_adapter translates it into the shape capabilities.py
+        parses.
+        """
+        if not self.access_token:
+            raise ZeekrAuthError("not logged in (no new-platform session)")
+        if not self.enc_vin:
+            raise ZeekrAuthError("no x-vin vehicle token configured")
+        resp = self._request(
+            "GET", "/ms-vehicle-capability/api/v1.0/vehicle/function/model/info",
+            query="", signer="snc")
+        data = resp.get("data")
+        return [r for r in data if isinstance(r, dict)] if isinstance(data, list) else []
+
     def vehicle_status_new_resp(self) -> dict:
         """Live status from the NEW gateway, for vehicles that live there.
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -64,13 +64,15 @@ class _Hass:
         return None
 
 
-def _build_all(**bundle_extra):
+def _build_all(entry=None, **bundle_extra):
     """Set up every platform and return {platform: [entities]}.
 
     `bundle_extra` overrides entries in the hass.data bundle - that is how the
     propulsion verdict reaches the platforms, so it is how the gating is tested.
+    `entry` overrides the config entry itself, for gates that read the entry
+    rather than the bundle.
     """
-    hass, entry = _Hass(), _Entry()
+    hass, entry = _Hass(), entry or _Entry()
     hass.data["geely_connect"] = {"e1": {
         "api": object(), "coordinator": _Coord(), "vin": FAKE_VIN,
         "device_name": "Geely EX5 (0000)", "capabilities": {}, **bundle_extra}}
@@ -195,6 +197,56 @@ def test_a_missing_or_unknown_verdict_keeps_the_charging_entities():
     for extra in ({}, {"propulsion": p.classify(None, None)}):
         got = _keys(_build_all(**extra))
         assert _CHARGING_KEYS <= got, _CHARGING_KEYS - got
+
+
+_NEW_PLATFORM_KEYS = frozenset({"bs_is_charging", "bs_is_plugged_in"})
+
+# Added by the same change as the two above, and present in BOTH platforms'
+# payloads - a gate that swept these up would delete six live entities from
+# every existing install.
+_BOTH_PLATFORM_KEYS = frozenset({
+    "bs_door_lock_driver", "bs_door_lock_passenger", "bs_door_lock_rear_left",
+    "bs_door_lock_rear_right", "trip_meter_2", "discharge_current",
+    "discharge_voltage",
+})
+
+
+def _new_platform_entry():
+    e = _Entry()
+    e.data = {"vin": FAKE_VIN, "pressure_unit": "psi", "platform": "zeekr"}
+    e.options = {"zeekr_enc_vin": "1eNc0d3d="}
+    return e
+
+
+def test_the_reported_charging_booleans_are_new_platform_only():
+    """`isCharging` / `isPluggedIn` are in the new platform's payload only, so
+    an old-platform car must not be given two tiles that can never say
+    anything."""
+    if not have_homeassistant():
+        skip("homeassistant not installed")
+    leaked = _keys(_build_all()) & _NEW_PLATFORM_KEYS
+    assert leaked == set(), leaked
+    got = _keys(_build_all(entry=_new_platform_entry()))
+    assert _NEW_PLATFORM_KEYS <= got, _NEW_PLATFORM_KEYS - got
+
+
+def test_the_gate_is_the_token_not_the_platform_name():
+    """A zeekr entry with no x-vin token still polls the legacy status path and
+    gets the legacy fields, so the token is what the gate has to read."""
+    if not have_homeassistant():
+        skip("homeassistant not installed")
+    e = _Entry()
+    e.data = {"vin": FAKE_VIN, "pressure_unit": "psi", "platform": "zeekr"}
+    leaked = _keys(_build_all(entry=e)) & _NEW_PLATFORM_KEYS
+    assert leaked == set(), leaked
+
+
+def test_the_platform_gate_takes_only_those_two_entities():
+    """The seven other fields promoted alongside them are on both platforms."""
+    if not have_homeassistant():
+        skip("homeassistant not installed")
+    got = _keys(_build_all())          # the default entry is an old-platform one
+    assert _BOTH_PLATFORM_KEYS <= got, _BOTH_PLATFORM_KEYS - got
 
 
 def test_full_exposure_keeps_fields_whose_curated_twin_was_not_built():

--- a/tests/test_zeekr_adapter.py
+++ b/tests/test_zeekr_adapter.py
@@ -302,3 +302,32 @@ def test_a_vehicle_with_the_new_token_reads_the_new_gateway():
     st = a.vehicle_status()
     assert st["code"] == 1000, "000000 was not translated"
     assert st["data"]["vehicleStatus"]["basicVehicleStatus"]["powerLevel"] == 55, st
+
+
+def test_the_capability_catalogue_is_fetched_and_translated():
+    a, c = _make_adapter()
+    c.enc_vin = "opaque-token"
+    c.capabilities_new = lambda: [
+        {"functionCode": "remote_climate_control", "paramValueUse": "Y"},
+        {"functionCode": "C_PAA_5_1", "paramValueUse": "Y"},
+        {"functionCode": "C_PAA_6", "paramValueUse": "Y"},
+    ]
+    entries = a.fetch_capabilities()
+    climate = [e for e in entries if e["functionId"] == "remote_climate_control_2"]
+    assert climate, entries
+    params = {p["nameKey"]: p["config"] for p in climate[0]["paramsJson"]}
+    assert params["dpt_heat_loc"] == "front-left"
+    assert params["steel_wheel_heating"] == "true"
+
+
+def test_a_catalogue_that_cannot_be_fetched_keeps_every_entity():
+    """Losing the catalogue must cost a car its feature *filtering*, never its
+    entities - an empty list is capabilities.py's permissive all-features view."""
+    a, c = _make_adapter()
+    c.enc_vin = "opaque-token"
+
+    def _boom():
+        raise zc.ZeekrApiError("code=8500 server internal error")
+
+    c.capabilities_new = _boom
+    assert a.fetch_capabilities() == []

--- a/tests/test_zeekr_capabilities.py
+++ b/tests/test_zeekr_capabilities.py
@@ -86,6 +86,14 @@ def test_disabled_rows_do_not_enable_anything():
         assert adapter.translate_capabilities(rows) == []
 
 
+def test_a_row_with_no_enable_flag_at_all_enables_nothing():
+    """`paramValueUse` is absent on some rows rather than "N" - a missing flag
+    is not an enabled feature."""
+    row = _row("honk_flash")
+    row["paramValueUse"] = None
+    assert adapter.translate_capabilities([row]) == []
+
+
 def test_an_empty_or_unknown_catalogue_stays_permissive():
     """Returning [] makes capabilities.py fall back to the all-features view,
     so a car whose catalogue we cannot read keeps every entity it has today."""

--- a/tests/test_zeekr_capabilities.py
+++ b/tests/test_zeekr_capabilities.py
@@ -1,0 +1,100 @@
+"""Translating the new platform's capability catalogue into the old shape.
+
+Rows here are copied from a real catalogue (Geely EX2, 74 rows, 2026-08-28).
+The vendor ships a `functionName` label with every row, which is what makes
+the service-shaped codes readable at all:
+
+    C_RDU_2_2  远程解锁-控制设备_后备箱   remote unlock, control device: tailgate
+    C_RWS_1    远程一键透气_远程车窗微开  one-touch ventilate: window slightly open
+    C_PAA_6    …PAA是否支持方向盘加热     steering-wheel heating supported
+"""
+from __future__ import annotations
+
+from conftest import load
+
+adapter = load("zeekr_adapter")
+capabilities = load("capabilities")
+
+
+def _row(code, use="Y", category="remote_control", param=None):
+    return {"functionCategory": category, "functionCode": code,
+            "functionName": "", "paramCode": param, "paramName": None,
+            "paramValueCode": None, "paramValueName": None,
+            "paramValueUse": use, "logicSymbol": None, "dataType": None}
+
+
+REAL = [
+    _row("remote_climate_control", param="control_device"),
+    _row("remote_control_lock_2", param="control_device"),
+    _row("remote_control_unlock_2", param="control_device"),
+    _row("remote_charge_2", param="battery_type"),
+    _row("remote_window_ventilate"),
+    _row("parking_comfortable_2"),
+    _row("honk_flash"),
+    _row("C_RDU_2_1"), _row("C_RDU_2_2"), _row("C_RDU_2_3"),
+    _row("C_RWS_1"), _row("C_RWS_1_5"),
+    _row("C_PAA_1"), _row("C_PAA_5_1"), _row("C_PAA_5_2"),
+    _row("C_PAA_6"), _row("C_PAA_9", use="1,2,3"),
+    _row("C_RHL_1"), _row("C_RHL_2"), _row("C_RHL_3"),
+    _row("V_RVS_8", category="remote_vehicle_status"),
+    _row("V_RVS_8_1", category="remote_vehicle_status"),
+    _row("sunroof_automatic_close", category="message_box",
+         param="notification_method"),
+]
+
+
+def _view(rows):
+    return capabilities.parse(adapter.translate_capabilities(rows))
+
+
+def test_the_features_this_car_has_survive_translation():
+    view = _view(REAL)
+    for flag in ("ac.enabled", "defrost.enabled", "charging.enabled",
+                 "find_car.enabled", "lock.enabled", "unlock.enabled",
+                 "tailgate.enabled", "window_vent.enabled", "windows.enabled",
+                 "seat.heat.enabled", "steering_wheel_heat.enabled",
+                 "parking_comfort.enabled"):
+        assert view.get(flag) is True, f"{flag} was lost in translation"
+
+
+def test_seat_positions_and_unlock_targets_come_from_the_codes():
+    view = _view(REAL)
+    assert view["seat.heat.positions"] == ["front-left", "front-right"]
+    assert set(view["unlock.targets"]) == {"door", "trunk", "hood"}
+
+
+def test_a_notification_row_is_not_a_feature():
+    """`sunroof_automatic_close` is a message_box preference, not a sunroof."""
+    view = _view(REAL)
+    assert "sunroof.enabled" not in view
+    assert "sunshade.enabled" not in view
+
+
+def test_defrost_is_asserted_because_the_service_cannot_be_asked():
+    """The climate entry is labelled 空调服务不区分命令 - the AC service does
+    not distinguish commands - so the catalogue cannot say whether defrost
+    exists. Asserting it keeps a working control; reading the silence as "no
+    defrost" would remove one."""
+    view = _view([_row("remote_climate_control")])
+    assert view.get("defrost.enabled") is True
+    assert view.get("ac.enabled") is True
+
+
+def test_disabled_rows_do_not_enable_anything():
+    for flag in ("N", "0", "", "false"):
+        rows = [_row("remote_charge_2", use=flag), _row("honk_flash", use=flag)]
+        assert adapter.translate_capabilities(rows) == []
+
+
+def test_an_empty_or_unknown_catalogue_stays_permissive():
+    """Returning [] makes capabilities.py fall back to the all-features view,
+    so a car whose catalogue we cannot read keeps every entity it has today."""
+    assert adapter.translate_capabilities([]) == []
+    assert adapter.translate_capabilities([_row("some_code_we_have_never_seen")]) == []
+
+
+def test_wheel_heat_needs_its_own_code():
+    without = _view([_row("remote_climate_control"), _row("C_PAA_5_1")])
+    assert "steering_wheel_heat.enabled" not in without
+    with_it = _view([_row("remote_climate_control"), _row("C_PAA_6")])
+    assert with_it.get("steering_wheel_heat.enabled") is True

--- a/tests/test_zeekr_new_platform.py
+++ b/tests/test_zeekr_new_platform.py
@@ -135,9 +135,10 @@ def test_wrapper_restores_the_old_platform_nesting():
           ["electricVehicleStatus"])
     assert basic["engineStatus"] == "engine-off"
     assert ev["chargeLevel"] == "92.0"
-    # Nothing is moved, so top-level readers keep working.
-    assert wrapped["updateTime"] == 1787817174561
-    # And it is ALSO carried inside vehicleStatus, where Car Reported At walks
+    # Moved, not copied: a second path to the same field would become a second
+    # raw diagnostic entity under full exposure.
+    assert "updateTime" not in wrapped
+    # It lives inside vehicleStatus, where Car Reported At walks
     # for it (vehicleStatus.updateTime). Without this the staleness sensor is
     # blank on every new-platform car - #24's failure with the one indicator
     # of it switched off (#53).

--- a/tests/test_zeekr_new_platform.py
+++ b/tests/test_zeekr_new_platform.py
@@ -32,6 +32,11 @@ _STATUS_DATA = {
     "updateTime": 1787817174561,
 }
 _LIST_DATA = [{"vin": FAKE_VIN, "nickName": "EX5", "tboxPlatform": "1"}]
+_CAP_DATA = [
+    {"functionCategory": "remote_control", "functionCode": "honk_flash",
+     "functionName": "远程闪灯鸣笛", "paramValueUse": "Y"},
+    "not a row",
+]
 
 
 def _start_gateway(seen: list[dict]):
@@ -56,8 +61,13 @@ def _start_gateway(seen: list[dict]):
                 "nonce": headers.get("x-api-signature-nonce", ""),
                 "signature_ok": headers.get("x-signature") == want,
             })
-            body = {"code": "000000", "msg": "ok",
-                    "data": _STATUS_DATA if "ms-vehicle-status" in path else _LIST_DATA}
+            if "ms-vehicle-status" in path:
+                data = _STATUS_DATA
+            elif "ms-vehicle-capability" in path:
+                data = _CAP_DATA
+            else:
+                data = _LIST_DATA
+            body = {"code": "000000", "msg": "ok", "data": data}
             raw = json.dumps(body).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -166,3 +176,56 @@ def test_wrapper_leaves_everything_else_alone():
     assert adapter._wrap_vehicle_status({"a": 1}) == {"a": 1}
     assert adapter._wrap_vehicle_status(None) is None
     assert adapter._wrap_vehicle_status("not a dict") == "not a dict"
+
+
+def test_capability_catalogue_is_read_with_no_query():
+    """The vehicle comes from the x-vin header, so the route takes no query at
+    all - asking it with ?vin= is what made this endpoint look unreachable."""
+    seen: list[dict] = []
+    srv = _start_gateway(seen)
+    try:
+        c = _client(srv)
+        c.enc_vin = "ENC-VIN-TOKEN=="
+        rows = c.capabilities_new()
+    finally:
+        srv.shutdown()
+    sent = seen[-1]
+    assert sent["path"] == (
+        "/ms-vehicle-capability/api/v1.0/vehicle/function/model/info")
+    assert sent["query"] == ""
+    assert sent["x_vin"] == "ENC-VIN-TOKEN=="
+    assert sent["signature_ok"]
+    # Non-dict entries in the list are dropped rather than handed on.
+    assert [r["functionCode"] for r in rows] == ["honk_flash"]
+
+
+def test_a_catalogue_that_is_not_a_list_reads_as_empty():
+    """A gateway answering with something other than a list of rows leaves the
+    catalogue empty, which capabilities.py reads as the permissive all-features
+    view rather than as a car with no features."""
+    c = zc.ZeekrClient(email="", password="", gateway="https://unused.invalid")
+    c.access_token = "test-access-token"
+    c.enc_vin = "ENC-VIN-TOKEN=="
+    c._request = lambda *a, **k: {"data": {"unexpected": "shape"}}
+    assert c.capabilities_new() == []
+
+
+def test_the_catalogue_refuses_to_run_unauthenticated():
+    """Both guards: no session, and no vehicle token."""
+    seen: list[dict] = []
+    srv = _start_gateway(seen)
+    try:
+        no_session = _client(srv)
+        no_session.access_token = ""
+        no_session.enc_vin = "ENC-VIN-TOKEN=="
+        no_token = _client(srv)          # authenticated, but no x-vin
+        for c in (no_session, no_token):
+            try:
+                c.capabilities_new()
+            except zc.ZeekrAuthError:
+                pass
+            else:  # pragma: no cover - only reached on a regression
+                raise AssertionError("the catalogue ran without credentials")
+    finally:
+        srv.shutdown()
+    assert not seen, "must not reach the gateway without credentials"


### PR DESCRIPTION
Split from #55 as you asked. This is the half you said you would take today: the capability parsing and the read entities, with no command code anywhere in it — `grep` for `control_new_resp` or `_translate_command` returns nothing on this branch. The commands are #55, rebased down to just themselves.

Rebased onto current `main`, so it sits on top of `0d73f6e`.

**Five commits, each green on its own:**

1. **Move the status blocks rather than copying them.** The wrapper currently does `wrapped = dict(data)` and then adds a filtered `vehicleStatus`, so `basicVehicleStatus.*` and `vehicleStatus.basicVehicleStatus.*` both resolve. The full-exposure sweep skips only curated paths, and those all start `vehicleStatus.`, so every duplicate becomes an extra raw diagnostic entity — about two hundred on this car, each a twin of one already on the list. `updateTime` moves with them, so `Car Reported At` keeps working. This changes one assertion in the test you landed with `0d73f6e` — the "nothing is moved, so top-level readers keep working" line — and the commit carries that change with it rather than leaving it for a later one.
2. **Nine fields promoted to curated entities**, the seven you confirmed against a real old-platform dump plus the two booleans.
3. **The capability catalogue**, translated into the shape `capabilities.py` parses.
4. **The two new-only booleans gated behind the x-vin token**, per your review, with a test pinning that the gate is exactly two entities wide and does not sweep up the other seven.
5. **Coverage for the catalogue route**, which had none.

**Verification.** 799 passed, 0 failed, 81 skipped (playwright). Coverage totals identical to `main`'s in my environment — `17` uncovered on both — so this adds no uncovered statement; `zeekr_adapter.py` and `binary_sensor.py` are at 100%. The README's entity counts are asserted against a real build by your own test, and they are updated: 83 on a battery-only car, 96 with a tank, 85 and 98 on the new platform.

On the asymmetric rule in commit 3, since it is the part I would most like a second opinion on: present code ⇒ enabled, absent ⇒ "not fitted" **only where the catalogue enumerates that feature**. Seat-heat positions arrive one code per seat, so a missing seat-vent code is real evidence; the climate entry is labelled 空调服务不区分命令 — "the AC service does not distinguish commands" — so it cannot speak to defrost, and reading that silence as "no defrost" would remove a control that works. An empty or unrecognised catalogue returns `[]`, which is the permissive all-features view, so this can never expose less than today.
