### PR TITLE
New platform: make position refresh work (PAI), and wake only when moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,11 +568,19 @@ profile at setup:
 
 | Mode | Charging / driving | Parked (base → cap) | Secondary data | GPS wake |
 |---|---|---|---|---|
-| 🌙 **Super Eco** - barely polls | every 5 min | 30 min → 2 h | every 2nd cycle | every 24th |
-| 🔋 **Eco** - fewest interruptions | every 90 s | 300 s → 30 min | every 6th cycle | every 12th |
-| ⚖️ **Normal** - balanced | every 30 s | 90 s → 15 min | every 4th cycle | every 6th |
-| ⚡ **Live** - freshest | every 15 s | 45 s → 5 min | every 3rd cycle | every 3rd |
+| 🌙 **Super Eco** - barely polls | every 5 min | 30 min → 2 h | every 2nd cycle | when it moves |
+| 🔋 **Eco** - fewest interruptions | every 90 s | 300 s → 30 min | every 6th cycle | when it moves |
+| ⚖️ **Normal** - balanced | every 30 s | 90 s → 15 min | every 4th cycle | when it moves |
+| ⚡ **Live** - freshest | every 15 s | 45 s → 5 min | every 3rd cycle | when it moves |
 | ✋ **Manual** - you sync | never | never | on every sync | on every sync |
+
+**"When it moves"** means the GPS wake fires while the car is driving, once more
+on the poll after it parks - so the parked location is always the last thing
+recorded - and again if the odometer moves without the integration seeing the
+trip. A car that has not moved is never woken to be asked where it is, however
+long it sits. (A car whose odometer cannot be read keeps the old per-cycle
+cadence, and **Refresh Data** forces a fix in any mode - which is also the
+answer for a car that is towed rather than driven.)
 
 The mode is **not fixed at setup** - change it any time from **Configure** on
 the device page (see *Changing settings later* below).
@@ -582,8 +590,8 @@ the device page (see *Changing settings later* below).
 Sits between Eco and Manual: the integration keeps updating on its own, but its
 *starting* interval is where Eco tops out, and two quiet polls reach a two-hour
 ceiling - a parked car costs roughly a dozen sessions a day against Eco's
-~fifty. Because the GPS wake-up reaches the car itself, Super Eco fires it at
-most once per 24 cycles - one wake every two days on a parked car - so it is
+~fifty. Because the GPS wake-up reaches the car itself, it fires only when the
+car has actually moved, so a car parked for a fortnight is never woken at all -
 frugal with the car's 12 V battery, not just with your phone-app session.
 
 Whenever you want more than that, **Refresh Data** is the other half of the

--- a/custom_components/geely_connect/__init__.py
+++ b/custom_components/geely_connect/__init__.py
@@ -264,6 +264,23 @@ _ENGINE_RUNNING = frozenset({"engine_running", "running", "on", "1", "true"})
 _STUCK_POLLS = 10
 
 
+def _odometer(d: dict) -> float | None:
+    """The car's cumulative distance, used as proof that it has moved.
+
+    Strictly increasing and present in every payload, which makes it the one
+    field that can answer "is the position we hold still where the car is?"
+    without asking the car - and asking the car costs a wake.
+    """
+    if not isinstance(d, dict):
+        return None
+    add = (d.get("vehicleStatus") or {}).get("additionalVehicleStatus") or {}
+    raw = (add.get("maintenanceStatus") or {}).get("odometer")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 def _poll_flags(d: dict) -> tuple[bool, bool]:
     """(charging, driving) from a status dict, tolerant of missing fields."""
     if not isinstance(d, dict):
@@ -465,7 +482,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _FAILURE_TOLERANCE = 2
     fail_state = {"consecutive": 0}
     # Efficient-polling state: cycle counter, idle streak, last-change signature.
-    poll_state = {"cycle": 0, "idle": 0, "sig": None}
+    poll_state = {"cycle": 0, "idle": 0, "sig": None, "fix_odo": None}
     # Chosen polling profile (Eco / Normal / Live) from setup.
     profile = POLL_PROFILES.get(
         # Options win over data: the polling mode can be changed after setup.
@@ -487,14 +504,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         prev = prev if isinstance(prev, dict) else {}
         was_charging, was_driving = _poll_flags(prev)
 
-        # Position wake (PAI) is expensive and actually wakes the car, so we do
-        # NOT fire it every cycle. Only while driving, once every Nth cycle
-        # when parked - or when the user pressed Refresh Data, whose contract
-        # is "everything, now". That last leg matters most in Super Eco, where
-        # the parked cadence is one wake in days and a manual pull is the
-        # advertised way to get a fresh fix on demand.
+        # Position wake (PAI) reaches the car and spends its 12 V, so it fires
+        # only when the fix we hold could be wrong: while driving (the map
+        # follows the car), on the first poll after a drive ends (`was_driving`
+        # reads the PREVIOUS snapshot, so parking still takes one last fix -
+        # where the car is parked is the reading an owner wants), when the
+        # odometer has moved since the last fix (a trip that began and ended
+        # inside one parked back-off window, speed zero on both sides), or on
+        # Refresh Data. It deliberately no longer fires on a bare timer: an
+        # odometer that has not moved is the car saying it is where it was, so a
+        # car parked for a fortnight is never woken. Movement without driving -
+        # towed, shipped - changes no odometer; Refresh Data covers that.
         forced = poll_state.get("force_secondary", False)
-        if was_driving or forced or ((cyc - 1) % _POSITION_EVERY == 0):
+        prev_odo, fix_odo = _odometer(prev), poll_state["fix_odo"]
+        have_proof = prev_odo is not None and fix_odo is not None
+        moved = have_proof and prev_odo > fix_odo
+        # The timer survives only for a car whose odometer we cannot read -
+        # then nothing is proven and the old cadence stands exactly as before,
+        # so no car loses coverage by this change. It also carries the very
+        # first cycle, when there is no previous snapshot to compare.
+        timer_due = (not have_proof) and ((cyc - 1) % _POSITION_EVERY == 0)
+        woke = was_driving or forced or moved or timer_due
+        if woke:
             try:
                 await _call_with_retry(api.request_position_refresh)
             except GeelyAuthError as e:
@@ -636,6 +667,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         else:
             poll_state["idle"] = 0
         poll_state["sig"] = sig
+        # Anchor the suppressor to the reading this cycle's fix belongs to, and
+        # only once the fresh payload is in hand - reading it from `prev` would
+        # anchor to the cycle before and re-fire for one extra wake.
+        if woke:
+            odo_now = _odometer(data)
+            if odo_now is not None:
+                poll_state["fix_odo"] = odo_now
 
         if not _MANUAL:
             try:

--- a/custom_components/geely_connect/zeekr_adapter.py
+++ b/custom_components/geely_connect/zeekr_adapter.py
@@ -321,19 +321,31 @@ class ZeekrAdapter:
                             self.vin, self.user_id)
 
     def request_position_refresh(self) -> dict:
-        """PAI wake (serviceId PAI / operation 4 / pai 1) on the legacy client.
+        """Wake the car for a fresh GPS fix (PAI - position acquisition).
 
-        Deliberately a no-op on the new platform: the coordinator fires this
-        automatically on the first poll and on every driving cycle, and the
-        control write path here is NOT live-verified on this backend (only door
-        lock/unlock is). Auto-sending an unproven command to the car on a timer
-        is exactly what the maintainer avoids, so until the PAI write is
-        confirmed we serve the position already in the status payload and skip
-        the active wake. The body it would send is kept for when it is proven:
+        The new gateway never streams position: the status payload carries the
+        last *located* fix and only refreshes when something asks the car for
+        one, which is why a migrated car's map could sit hours stale while every
+        other value was live (#53). The Geely app fires this on every map open.
 
-          {command: start, serviceId: PAI, serviceParameters:
-             [{operation: 4}, {pai: 1}], userId, timestamp}
+        Capture-verified on the new gateway (2026-08-29): the request is
+        serviceId PAI with a single `pai=1` parameter, sent through the same
+        control route as any other new-platform command. The legacy
+        `operation=4` parameter is rejected here (037000 parameter incorrect),
+        so only `pai=1` is sent. PAI *acquires* a position - there is no
+        variant of it that moves or opens the car - so unlike the lock/unlock
+        mapping its failure mode is benign.
+
+            {"command": "start", "serviceId": "PAI",
+             "setting": {"serviceParameters": [{"key": "pai", "value": "1"}]}}
+
+        The gateway ACKs immediately; the fresh fix lands in the status payload
+        a few seconds later, which the next poll reads. On a vehicle without an
+        x-vin token this stays a no-op, exactly as before.
         """
+        if self._client.enc_vin:
+            return self._authed(self._client.control_new_resp, "PAI", "start",
+                                [{"key": "pai", "value": "1"}])
         return {}
 
     def vehicle_status_state(self) -> dict:

--- a/custom_components/geely_connect/zeekr_client.py
+++ b/custom_components/geely_connect/zeekr_client.py
@@ -931,6 +931,34 @@ class ZeekrClient:
         data = resp.get("data")
         return [r for r in data if isinstance(r, dict)] if isinstance(data, list) else []
 
+    def control_new_resp(self, service_id: str, command: str,
+                         parameters: list[dict] | None = None) -> dict:
+        """Send a command on the NEW gateway (capture-verified).
+
+        POST /ms-remote-control/v1.0/remoteControl/control - note no `/api/`
+        segment on this service, and a much smaller body than the old
+        platform's: no creator, operationScheduling, timestamp, userId or vin,
+        and serviceParameters nested under `setting`. The vehicle is
+        identified by the `x-vin` header alone.
+
+            {"command": "start", "serviceId": "RDL",
+             "setting": {"serviceParameters": [{"key": "door",
+                                                "value": "all"}]}}
+        -> {"code": "000000", "data": {"sessionId": "..."}}
+        """
+        if not self.access_token:
+            raise ZeekrAuthError("not logged in (no new-platform session)")
+        if not self.enc_vin:
+            raise ZeekrAuthError("no x-vin vehicle token configured")
+        body = {
+            "command": command,
+            "serviceId": service_id,
+            "setting": {"serviceParameters": parameters or []},
+        }
+        return self._request(
+            "POST", "/ms-remote-control/v1.0/remoteControl/control",
+            body=json.dumps(body).encode(), signer="snc")
+
     def vehicle_status_new_resp(self) -> dict:
         """Live status from the NEW gateway, for vehicles that live there.
 

--- a/tests/test_init_lifecycle.py
+++ b/tests/test_init_lifecycle.py
@@ -1005,3 +1005,95 @@ def test_a_probe_without_a_coordinator_still_sends_the_command():
             AssertionError("must not be called without a coordinator"))):
         run()
     assert any(c[0] == "control" for c in api.calls)
+
+
+# ------------------------------------------------ when to wake the car ---
+# The position wake reaches the car itself and costs 12 V charge, so it fires
+# when the fix we hold could be wrong - not on a timer. The odometer is what
+# makes that knowable without asking: strictly increasing, in every payload.
+
+def _snap(speed, odo):
+    return {"code": 1000, "data": {"vehicleStatus": {
+        "basicVehicleStatus": {"speed": speed},
+        "additionalVehicleStatus": {
+            "electricVehicleStatus": {"statusOfChargerConnection": "0",
+                                      "chargeLevel": "80"},
+            "maintenanceStatus": {"odometer": odo}}}}}
+
+
+def _wakes(api):
+    return api.calls.count("position")
+
+
+def test_a_parked_car_is_not_woken_to_re_ask_where_it_is():
+    """The change this replaces woke a car every Nth poll while parked - about
+    every ninety minutes on Normal, for a fortnight at an airport. An odometer
+    that has not moved is the car already saying it is where it was."""
+    m = _mod()
+    _, _, _, api, coord, _ = _setup(m)
+    api.status_results = [_snap("0", "2174") for _ in range(6)]
+    for _ in range(6):
+        asyncio.run(coord.refresh())
+    before = _wakes(api)
+    api.status_results = [_snap("0", "2174") for _ in range(10)]
+    for _ in range(10):
+        asyncio.run(coord.refresh())
+    assert _wakes(api) == before, "a stationary car was woken again"
+
+
+def test_the_last_fix_of_a_drive_is_taken_once_the_car_has_parked():
+    """Where the car is parked is the reading an owner actually wants, and it
+    only exists after the car stops. `was_driving` reads the PREVIOUS snapshot,
+    so the first parked cycle still sees driving and takes that final fix."""
+    m = _mod()
+    _, _, _, api, coord, _ = _setup(m)
+    api.status_results = [_snap("0", "2174"), _snap("0", "2174")]
+    for _ in range(2):
+        asyncio.run(coord.refresh())
+    quiet = _wakes(api)
+
+    api.status_results = [_snap("60", "2180"), _snap("55", "2186")]
+    for _ in range(2):
+        asyncio.run(coord.refresh())
+    assert _wakes(api) > quiet, "the map must follow a moving car"
+
+    driving = _wakes(api)
+    api.status_results = [_snap("0", "2192")]
+    asyncio.run(coord.refresh())
+    assert _wakes(api) == driving + 1, "no final fix once the car parked"
+
+    parked = _wakes(api)
+    api.status_results = [_snap("0", "2192") for _ in range(5)]
+    for _ in range(5):
+        asyncio.run(coord.refresh())
+    assert _wakes(api) == parked, "it kept waking a car that had already parked"
+
+
+def test_a_trip_this_integration_never_saw_still_refreshes_the_fix():
+    """A drive can begin and end inside one parked back-off window - fifteen
+    minutes on Normal - leaving speed at zero on both sides of it. The odometer
+    is the only evidence left that the fix we hold is somewhere else."""
+    m = _mod()
+    _, _, _, api, coord, _ = _setup(m)
+    api.status_results = [_snap("0", "2174") for _ in range(4)]
+    for _ in range(4):
+        asyncio.run(coord.refresh())
+    settled = _wakes(api)
+
+    api.status_results = [_snap("0", "2192"), _snap("0", "2192")]
+    for _ in range(2):
+        asyncio.run(coord.refresh())
+    assert _wakes(api) > settled, "an unobserved trip left a stale position"
+
+
+def test_a_car_with_no_readable_odometer_keeps_the_old_cadence():
+    """Nothing is proven without an odometer, so the timer stands exactly as it
+    did - this change must not cost any car its coverage."""
+    m = _mod()
+    _, _, _, api, coord, _ = _setup(m)
+    api.status_results = [_snap("0", None) for _ in range(12)]
+    for _ in range(12):
+        asyncio.run(coord.refresh())
+    profile_n = 6      # POLL_PROFILES["normal"]["position_every"]
+    assert _wakes(api) >= 12 // profile_n, "the fallback timer stopped firing"
+

--- a/tests/test_polling_logic.py
+++ b/tests/test_polling_logic.py
@@ -60,6 +60,18 @@ def test_charging_is_detected_from_the_connection_status():
         assert m._poll_flags(_status(charger=other))[0] is False, other
 
 
+def test_the_odometer_reads_through_junk_without_raising():
+    """It gates the position wake, so anything unreadable has to mean "no
+    proof" rather than an exception on the poll path."""
+    m = _coordinator_module()
+    assert m._odometer(_status(odo="2174.5")) == 2174.5
+    for junk in (None, "", "n/a", [], {}, "not a number"):
+        assert m._odometer(_status(odo=junk)) is None, junk
+    for not_a_payload in (None, "", [], 7):
+        assert m._odometer(not_a_payload) is None, not_a_payload
+    assert m._odometer({}) is None
+
+
 def test_driving_is_any_positive_speed():
     m = _coordinator_module()
     assert m._poll_flags(_status(speed="42"))[1] is True
@@ -423,7 +435,7 @@ def test_a_refresh_press_forces_the_position_wake_too():
     import io, os
     from conftest import PKG
     src = io.open(os.path.join(PKG, "__init__.py"), encoding="utf-8").read()
-    assert "if was_driving or forced or ((cyc - 1) % _POSITION_EVERY == 0):" in src
+    assert "woke = was_driving or forced or moved or timer_due" in src
     assert src.count('poll_state.get("force_secondary", False)') == 1, (
         "forced is read twice; the two gates can disagree about one press")
 

--- a/tests/test_zeekr_adapter.py
+++ b/tests/test_zeekr_adapter.py
@@ -331,3 +331,26 @@ def test_a_catalogue_that_cannot_be_fetched_keeps_every_entity():
 
     c.capabilities_new = _boom
     assert a.fetch_capabilities() == []
+
+
+def test_position_refresh_sends_the_pai_wake_on_the_new_platform():
+    """With an x-vin token, request_position_refresh fires the PAI locator
+    through the control transport - serviceId PAI, pai=1 - which is what makes
+    a new-platform car's map refresh at all."""
+    a, c = _make_adapter()
+    c.enc_vin = "opaque-token"
+    sent = []
+    c.control_new_resp = lambda sid, cmd, params=None: (
+        sent.append((sid, cmd, params)) or {"code": "000000", "data": {}})
+    a.request_position_refresh()
+    assert sent == [("PAI", "start", [{"key": "pai", "value": "1"}])], sent
+
+
+def test_position_refresh_is_a_no_op_without_a_token():
+    """A vehicle with no x-vin token is on the old platform (or unconfigured);
+    the legacy client owns its PAI, so this side must not reach the car."""
+    a, c = _make_adapter()   # enc_vin defaults to ""
+    called = []
+    c.control_new_resp = lambda *a_, **k: called.append(1) or {}
+    assert a.request_position_refresh() == {}
+    assert called == [], "must not send a new-platform command without a token"

--- a/tests/test_zeekr_new_platform.py
+++ b/tests/test_zeekr_new_platform.py
@@ -67,7 +67,26 @@ def _start_gateway(seen: list[dict]):
                 data = _CAP_DATA
             else:
                 data = _LIST_DATA
-            body = {"code": "000000", "msg": "ok", "data": data}
+            self._reply({"code": "000000", "msg": "ok", "data": data})
+
+        def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler's spelling
+            length = int(self.headers.get("Content-Length") or 0)
+            body = self.rfile.read(length)
+            headers = {k.lower(): v for k, v in self.headers.items()}
+            want = zc.snc_sign(
+                method="POST",
+                url=f"http://127.0.0.1:{self.server.server_address[1]}{self.path}",
+                headers=dict(self.headers), body=body)
+            seen.append({
+                "path": self.path,
+                "body": json.loads(body or b"{}"),
+                "x_vin": headers.get("x-vin"),
+                "signature_ok": headers.get("x-signature") == want,
+            })
+            self._reply({"code": "000000", "msg": "ok",
+                         "data": {"sessionId": "abc123"}})
+
+        def _reply(self, body):
             raw = json.dumps(body).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -267,3 +286,81 @@ def test_status_read_refuses_without_a_session():
         pass
     else:  # pragma: no cover - only on a regression
         raise AssertionError("status read ran without a session")
+
+
+def test_the_control_route_sends_the_captured_envelope():
+    """control_new_resp is the shared transport for every new-platform command:
+    POST /ms-remote-control/v1.0/remoteControl/control, no /api/ segment,
+    serviceParameters nested under `setting`, vehicle addressed by x-vin, and
+    the body inside the signed canonical."""
+    seen: list[dict] = []
+    srv = _start_gateway(seen)
+    try:
+        c = _client(srv)
+        c.enc_vin = "ENC-VIN-TOKEN=="
+        resp = c.control_new_resp("RDL", "start",
+                                  [{"key": "door", "value": "all"}])
+    finally:
+        srv.shutdown()
+    sent = seen[-1]
+    assert sent["path"] == "/ms-remote-control/v1.0/remoteControl/control"
+    assert sent["body"] == {
+        "command": "start", "serviceId": "RDL",
+        "setting": {"serviceParameters": [{"key": "door", "value": "all"}]}}
+    assert sent["x_vin"] == "ENC-VIN-TOKEN=="
+    assert sent["signature_ok"], "the body must be inside the signed canonical"
+    assert resp["data"]["sessionId"] == "abc123"
+
+
+def test_a_command_with_no_parameters_still_sends_the_list():
+    seen: list[dict] = []
+    srv = _start_gateway(seen)
+    try:
+        c = _client(srv)
+        c.enc_vin = "ENC-VIN-TOKEN=="
+        c.control_new_resp("RHL", "start")
+    finally:
+        srv.shutdown()
+    assert seen[-1]["body"]["setting"] == {"serviceParameters": []}
+
+
+def test_the_control_route_refuses_to_run_unauthenticated():
+    """A command must never leave without both a session and a vehicle token."""
+    seen: list[dict] = []
+    srv = _start_gateway(seen)
+    try:
+        no_session = _client(srv)
+        no_session.access_token = ""
+        no_session.enc_vin = "ENC-VIN-TOKEN=="
+        no_token = _client(srv)          # authenticated, but no x-vin
+        for c in (no_session, no_token):
+            try:
+                c.control_new_resp("RDL", "start")
+            except zc.ZeekrAuthError:
+                pass
+            else:  # pragma: no cover - only reached on a regression
+                raise AssertionError("a command ran without credentials")
+    finally:
+        srv.shutdown()
+    assert not seen, "must not reach the gateway without credentials"
+
+
+def test_the_position_wake_sends_the_captured_pai_request():
+    """request_position_refresh is the whole point of the transport here: the
+    map-open locator, serviceId PAI with a single pai=1 parameter (the legacy
+    operation=4 is rejected on this gateway). It acquires a position; it cannot
+    move the car."""
+    seen: list[dict] = []
+    srv = _start_gateway(seen)
+    try:
+        c = _client(srv)
+        c.enc_vin = "ENC-VIN-TOKEN=="
+        c.control_new_resp("PAI", "start", [{"key": "pai", "value": "1"}])
+    finally:
+        srv.shutdown()
+    sent = seen[-1]
+    assert sent["path"] == "/ms-remote-control/v1.0/remoteControl/control"
+    assert sent["body"] == {
+        "command": "start", "serviceId": "PAI",
+        "setting": {"serviceParameters": [{"key": "pai", "value": "1"}]}}
+    assert sent["signature_ok"]


### PR DESCRIPTION
This closes the open thread in `request_position_refresh`'s own docstring on `main` — *"until the PAI write is confirmed"* — it's confirmed. It's the split you asked for: **one self-contained "make location work on the new platform" story**, with no lock/unlock mapping in it (`grep _translate_command` returns nothing here). #55 rebases to just the mapping on top of this.

Rebased onto current `main` (v1.47.0).

**Why it's needed.** The new gateway never streams position — the status payload carries the last *located* fix and only moves when something asks the car for one. On the new platform `request_position_refresh` was a no-op, so nothing ever asked. The owner on #53 watched his migrated car read `home` for **ninety-nine minutes** after it had driven 18 km away, with every other value live and nothing saying the location was stale.

**The fix, capture-verified on a real new-platform car (2026-08-29).** The app's map-open locator is `serviceId PAI` with a single `pai=1` parameter, sent through the same control route as any other new-platform command:

```
POST /ms-remote-control/v1.0/remoteControl/control
{"command":"start","serviceId":"PAI","setting":{"serviceParameters":[{"key":"pai","value":"1"}]}}
```

The catalogue advertises it (`C_PAI_1 位置获取服务`, use=Y). The legacy `operation=4` parameter is rejected on this gateway (`037000 parameter is incorrect`), so only `pai=1` is sent — and that error, versus the fake `000000` some endpoints return for anything, is how the shape was pinned. Verified end to end: the ACK returns, and the fix in the status payload advances from stale to current within seconds.

**Two commits, each green on its own:**

1. **The PAI mechanism.** Adds the shared new-platform control transport (`control_new_resp`) and uses it for exactly one thing — the position wake. **PAI *acquires* a position; there is no variant of it that moves or opens the car**, so unlike the lock/unlock mapping (#55) its failure mode is benign. A vehicle with no x-vin token stays a no-op, so nothing changes for any existing entry.

2. **Wake only when moved.** Now that the wake reaches the car and costs 12 V, *when* it fires matters. It fires while driving, once more when the car parks (so the parked spot is always recorded), and again if the odometer shows a trip the integration never saw — but **never on a bare timer**, so a car parked for a fortnight is never woken. A car whose odometer can't be read keeps the old per-cycle cadence, so no car loses coverage. This half is platform-agnostic — it improves the old platform's battery behaviour too.

**Verification.** 816 passed, 0 failed, 81 skipped (playwright). **Coverage 100%** — `__init__.py`, `zeekr_adapter.py` and `zeekr_client.py` all at 100%, TOTAL 0 uncovered, so it clears the `--fail-under=100` gate you restored in `33307ae`. Tests pin the control envelope, both credential guards, the exact PAI request, the adapter routing, and the wake behaviour driven through the real poll loop across a park cycle.

Running on the reporter's own car now; the map self-updates.
