### PR TITLE
Cards: user-supplied car photo, and tap-to-expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,11 +296,26 @@ Everything else is optional:
 | `battery_bold:` | `true` | Set `false` to draw the battery-% headline in a regular weight instead of bold |
 | `charge_time_format:` | `min` | How **Time to full** reads while charging: `min` (e.g. `249 min`) or `hm` for hours + minutes (e.g. `4h 9m`) |
 | `show_parked:` | `false` | Compact card only. `true` adds a **Parked** chip next to Locked while the car is stationary, matching the full card's status |
+| `car_image:` | *none* | Path or URL to your own photo of the car (e.g. `/local/geely/mycar.png` for a file in `config/www/geely/`). It replaces the drawn car while keeping the live overlay - headlights, tail lights, charge port and the open-panel markers. Transparent PNG/WebP, side-on, front to the left works best |
+| `car_image_hotspots:` | *sensible defaults* | Fine-tune where the overlay lights sit on your image, as percentages, if a different crop needs it - e.g. `{headlight: [8, 46], taillight: [94, 37], port: [86, 40]}` |
 
 ```yaml
 type: custom:geely-card
 nav: [apple, here]        # an iPhone with HERE WeGo on it
 nav_travel: walking       # you are walking to the car
+```
+
+**Your own car, and tap to expand.** By default the card draws a generic
+electric crossover. Point `car_image` at a photo of your actual car - colour and
+all - and it shows that instead, with the live indicators (lamps, charge port,
+open-panel markers) drawn on top so nothing is lost. Because the image is your
+own file under `config/www/`, it is untouched by add-on updates. On the compact
+summary card, tapping the car opens the full card in a pop-up, so a small tile
+can still reach every control.
+
+```yaml
+type: custom:geely-card-compact
+car_image: /local/geely/mycar.webp   # your photo in config/www/geely/
 ```
 
 #### The climate panel

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -294,6 +294,41 @@
       <circle class="ind ${open.hood ? "on" : ""}" cx="598" cy="116" r="7"/>
     </svg>`;
 
+  /* ------------------------------------------- the owner's own car ----- */
+  /* A photograph instead of the drawing. The drawing is live UI - lamps and
+   * open-panel markers - and a flat image is not, so the state is put back as
+   * an overlay: percentages of the image box rather than SVG coordinates, so
+   * one set of positions fits any side profile of roughly the same crop.
+   *
+   * Measured against a manufacturer side render, front at the LEFT, which is
+   * how these are almost always shot. `car_image_hotspots` overrides any of
+   * them for an image framed differently. */
+  const PHOTO_SPOTS = {
+    // Measured off the lamps themselves rather than judged by eye: the tail
+    // lamp from its red pixels, the headlight from the dark lens, the charge
+    // flap from the two vertical edges of its outline in the quarter panel.
+    headlight: [8.5, 45.5], taillight: [94.3, 37.3], port: [86.2, 39.5],
+    hood: [15, 38], front: [50, 37], rear: [75, 37], trunk: [91, 24],
+  };
+
+  const CAR_PHOTO = (cls, open, cfg, lamps) => {
+    const S = Object.assign({}, PHOTO_SPOTS, cfg.car_image_hotspots || {});
+    const at = (k) => `left:${S[k][0]}%; top:${S[k][1]}%`;
+    const lamp = (k, on) =>
+      `<i class="lamp ${k}${on ? " on" : ""}" style="${at(k)}"></i>`;
+    const ind = (k) =>
+      `<i class="pind${open[k] ? " on" : ""}" style="${at(k)}"></i>`;
+    return `
+      <div class="photo ${cls}">
+        <img src="${esc(cfg.car_image)}" alt="">
+        <span class="lamps">
+          ${lamp("headlight", lamps.head)}${lamp("taillight", lamps.tail)}
+          <i class="lamp port" style="${at("port")}"></i>
+          ${ind("hood")}${ind("front")}${ind("rear")}${ind("trunk")}
+        </span>
+      </div>`;
+  };
+
   const _WHEEL = `
       <circle class="tire" r="62"/>
       <circle class="disc" r="42"/>
@@ -502,6 +537,44 @@
     .num { font-weight: 200; font-variant-numeric: tabular-nums; letter-spacing: -0.02em; line-height: 1; }
 
     .car { width: 100%; height: auto; display: block; }
+    /* The compact card's car is a doorway to the full one. */
+    .carwrap.expandable { cursor: pointer; border-radius: 10px; outline: none;
+      transition: transform .18s ease, filter .18s ease; }
+    .carwrap.expandable:hover { transform: translateY(-1px); filter: brightness(1.06); }
+    .carwrap.expandable:focus-visible { box-shadow: 0 0 0 2px ${ACCENT}; }
+    /* the photo variant - see CAR_PHOTO */
+    .photo { position: relative; width: 100%; line-height: 0; }
+    .photo img { width: 100%; height: auto; display: block; }
+    /* A wrong path must not leave lamps floating over a broken-image glyph. */
+    .photo.broken img { visibility: hidden; }
+    .photo.broken .lamps { display: none; }
+    .photo .lamps { position: absolute; inset: 0; pointer-events: none; }
+    .photo .lamp, .photo .pind {
+      position: absolute; transform: translate(-50%,-50%); border-radius: 50%;
+    }
+    .photo .lamp { opacity: 0; transition: opacity .45s ease; }
+    .photo .lamp.on { opacity: 1; }
+    .photo .lamp.headlight { width: 13%; height: 19%; filter: blur(2px);
+      background: radial-gradient(ellipse at center,
+        rgba(255,250,235,.95), rgba(205,230,255,.4) 45%, transparent 70%); }
+    .photo .lamp.taillight { width: 11%; height: 17%; filter: blur(2px);
+      background: radial-gradient(ellipse at center,
+        rgba(255,80,80,.95), rgba(225,40,40,.4) 45%, transparent 70%); }
+    .photo .lamp.port { width: 9%; height: 17%; filter: blur(1.5px);
+      background: radial-gradient(ellipse at center,
+        ${ACCENT}, transparent 65%); }
+    .photo.plugged .lamp.port { opacity: .4; }
+    .photo.braked .lamp.taillight { opacity: .38; }
+    .photo .lamp.taillight.on { opacity: 1; }
+    .photo.charging .lamp.port { opacity: 1; animation: geely-throb 1.9s ease-in-out infinite; }
+    .photo .pind { width: 13px; height: 13px; background: ${AMBER};
+      opacity: 0; transition: opacity .3s ease;
+      box-shadow: 0 0 9px 2px ${AMBER}; }
+    .photo .pind.on { opacity: 1; animation: geely-blink 1.4s ease infinite; }
+    @keyframes geely-throb {
+      0%,100% { opacity: 1; filter: blur(1.5px); }
+      50%     { opacity: .45; filter: blur(3px); }
+    }
     .car .shadow { fill: rgba(0,0,0,.28); }
     .car .glow { fill: transparent; transition: fill .5s ease; }
     .car .paint { fill: var(--geely-car-paint, url(#gp)); stroke: rgba(0,0,0,.18); stroke-width: 1.5; }
@@ -765,6 +838,18 @@
 
   /* ------------------------------------------------------------ base ----- */
 
+  // ::backdrop cannot be set inline, so the expand dialog's backdrop needs a
+  // real stylesheet rule. Injected once into the document head (the dialog
+  // lives in document.body, not a shadow root - see _openFullCard).
+  let _expandBackdropDone = false;
+  const _ensureExpandBackdropStyle = () => {
+    if (_expandBackdropDone) return;
+    _expandBackdropDone = true;
+    const st = document.createElement("style");
+    st.textContent = "dialog.geely-expand::backdrop{background:rgba(0,0,0,.62)}";
+    document.head.appendChild(st);
+  };
+
   class GeelyCardBase extends HTMLElement {
     static getStubConfig() { return {}; }
 
@@ -787,6 +872,14 @@
       // A pending arm-timeout must not fire a render on a removed card.
       clearTimeout(this._armedTimer);
       this._armed = null;
+      // The expand dialog lives in document.body, so it will not be removed
+      // with the card's own DOM - take it with us.
+      if (this._expandDialog) {
+        try { this._expandDialog.close(); } catch (e) { /* not open */ }
+        this._expandDialog.remove();
+        this._expandDialog = null;
+        this._expandCard = null;
+      }
     }
 
     setConfig(config) {
@@ -825,6 +918,12 @@
     _safeRender() {
       try {
         this._render();
+        this._wirePhoto();
+        this._wireExpand();
+        // A dialog left open must not freeze at the values it had when it opened.
+        if (this._expandCard && this._expandDialog && this._expandDialog.open) {
+          this._expandCard.hass = this._hass;
+        }
       } catch (err) {
         this.shadowRoot.innerHTML = `<style>${BASE_CSS}</style>
           <div class="shell"><p class="micro">Geely Card</p>
@@ -1410,6 +1509,103 @@
                 title="${esc(opts.title || label)}">${icon(ic)}<span>${esc(text)}</span></button>`;
     }
 
+    /* The car drawing, or the owner's own photo of it when `car_image` is set.
+     * The drawing carries live state, so the photo has to as well: headlamps
+     * while the car is moving, tail lamps while it is moving or held on the
+     * park brake, and the charge port lit from the same states that drive the
+     * drawing's port dot. */
+    _carBody(cls) {
+      const open = this._openMap();
+      if (!this._config.car_image) return CAR_SVG(cls, open);
+      const on = (d) => {
+        const st = this._st(`binary_sensor.${d}`);
+        return !!st && st.state === "on";
+      };
+      const driving = this._isDriving();
+      const plugged = on("charger_plug") || on("is_plugged_in");
+      // Two levels, the same shape as the charge port: full while the car is
+      // moving, a dim ember while it sits on the park brake. The brake is
+      // engaged the whole time a car is parked, so lighting it fully would
+      // leave the tail lamps burning in every screenshot of a stationary car.
+      const braked = on("park_brake_engaged");
+      return CAR_PHOTO(
+        `${cls}${plugged ? " plugged" : ""}${braked ? " braked" : ""}`,
+        open, this._config, { head: driving, tail: driving });
+    }
+
+    /* Tapping the car on a summary card opens the full card in a modal, rather
+     * than sending the user off to another view. The dialog hosts a real
+     * <geely-card>, so it is the same card with the same behaviour - not a
+     * second rendering of it that could drift. Built once, then kept fed with
+     * every hass update so it stays live while open. */
+    _wireExpand() {
+      const wrap = this.shadowRoot.querySelector(".carwrap.expandable");
+      if (!wrap || wrap.dataset.wired) return;
+      wrap.dataset.wired = "1";
+      const open = (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        this._openFullCard();
+      };
+      wrap.addEventListener("click", open);
+      wrap.addEventListener("keydown", (ev) => {
+        if (ev.key === "Enter" || ev.key === " ") open(ev);
+      });
+    }
+
+    _openFullCard() {
+      if (!this._expandDialog) {
+        const dlg = document.createElement("dialog");
+        dlg.className = "geely-expand";
+        // Centre it ourselves with inline styles. The dialog is appended to
+        // document.body (below), not the shadow root, so the <style> in this
+        // card's shadow DOM does not reach it - and it MUST live outside the
+        // card, because a modal <dialog> promoted to the top layer centres
+        // against its containing block, and Lovelace's masonry/section layouts
+        // put a `transform` on an ancestor of the card. Inside the shadow root
+        // that transform becomes the containing block, so the dialog lands in
+        // a corner instead of the viewport. In document.body there is no such
+        // ancestor, and `inset:0; margin:auto` centres it on both axes.
+        dlg.style.cssText = [
+          "position:fixed", "inset:0", "margin:auto",
+          "width:min(520px,96vw)", "max-height:92vh", "overflow-y:auto",
+          "overscroll-behavior:contain", "border:none", "padding:0",
+          "background:transparent", "color:inherit",
+        ].join(";");
+        _ensureExpandBackdropStyle();
+        const card = document.createElement("geely-card");
+        try {
+          card.setConfig({ ...(this._config || {}) });
+        } catch (err) {
+          console.warn("geely-card: could not build the expanded card:", err);
+          return;
+        }
+        // Click the backdrop to dismiss. Escape is native to <dialog>.
+        dlg.addEventListener("click", (ev) => { if (ev.target === dlg) dlg.close(); });
+        dlg.appendChild(card);
+        document.body.appendChild(dlg);
+        this._expandDialog = dlg;
+        this._expandCard = card;
+      }
+      this._expandCard.hass = this._hass;
+      this._expandDialog.showModal();
+    }
+
+    /* An unreachable image must fail quietly rather than leaving lamps hovering
+     * over a broken-image glyph. Inline handlers are avoided because a strict
+     * CSP would drop them silently. */
+    _wirePhoto() {
+      const img = this.shadowRoot.querySelector(".photo img");
+      if (!img || img.dataset.wired) return;
+      img.dataset.wired = "1";
+      const fail = () => {
+        const box = img.closest(".photo");
+        if (box) box.classList.add("broken");
+      };
+      if (img.complete && img.naturalWidth === 0) fail();
+      img.addEventListener("error", fail, { once: true });
+    }
+
     _openMap() {
       const on = (d) => { const st = this._st(`binary_sensor.${d}`); return st && st.state === "on"; };
       return {
@@ -1637,7 +1833,8 @@
               <div class="micro sub">${esc(this._rangeLabel(s))}</div>
               ${split ? `<div class="micro sub">${esc(split)}</div>` : ""}
             </div>
-            <div class="carwrap">${CAR_SVG(s.charging ? "charging" : "", this._openMap())}</div>
+            <div class="carwrap expandable" role="button" tabindex="0"
+                 title="Open the full card">${this._carBody(s.charging ? "charging" : "")}</div>
           </div>
           <div style="margin:2px 0 10px">${this._bars(s)}</div>
           <div class="chips" style="margin-bottom:12px">${chips || `<span class="chip">${driving ? "Driving" : "Parked"}</span>`}</div>
@@ -1796,7 +1993,7 @@
           </div>
           ${this._bars(s)}
 
-          <div class="carwrap">${CAR_SVG(s.charging ? "charging" : "", this._openMap())}</div>
+          <div class="carwrap">${this._carBody(s.charging ? "charging" : "")}</div>
 
           <div class="actions" style="margin-top:8px">
             ${this._actBtn("lock", "Lock", "lock", { on: s.locked && s.locked.state === "locked" })}

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -1783,3 +1783,55 @@ def test_a_seat_button_fills_in_proportion_to_its_level():
     off = _lvl("Off")
     assert off["lvl"] in ("0", ""), off
     assert "lvl" not in off["cls"], "an off seat must not carry the fill class"
+
+
+# --------------------------------- user-supplied car image + tap to expand ---
+
+def test_a_car_image_replaces_the_drawing_and_keeps_the_state_overlay():
+    """With car_image set, the card shows the owner's photo instead of the
+    drawn SVG - but the live state has to survive, so the lamp/marker overlay
+    is drawn on top."""
+    got = _mount("geely-card", """{
+            hasImg: !!el.shadowRoot.querySelector('.photo img'),
+            src: (el.shadowRoot.querySelector('.photo img') || {}).getAttribute
+                 ? el.shadowRoot.querySelector('.photo img').getAttribute('src') : null,
+            overlay: !!el.shadowRoot.querySelector('.photo .lamps'),
+            noSvgCar: !el.shadowRoot.querySelector('svg.car'),
+        }""", cfg={"car_image": "/local/geely/mycar.webp"})
+    assert got["hasImg"] is True, got
+    assert got["src"] == "/local/geely/mycar.webp", got
+    assert got["overlay"] is True, got
+    assert got["noSvgCar"] is True, got
+
+
+def test_without_a_car_image_the_drawn_car_is_kept():
+    got = _mount("geely-card", """{
+            svgCar: !!el.shadowRoot.querySelector('svg.car'),
+            noPhoto: !el.shadowRoot.querySelector('.photo'),
+        }""")
+    assert got["svgCar"] is True, got
+    assert got["noPhoto"] is True, got
+
+
+def test_the_summary_card_makes_the_car_a_button_that_opens_the_full_card():
+    """Tapping the car on the compact card opens the full card in a modal
+    appended to document.body (so it centres against the viewport, not a
+    transformed dashboard ancestor)."""
+    got = _mount("geely-card-compact", """(() => {
+            const wrap = el.shadowRoot.querySelector('.carwrap.expandable');
+            if (!wrap) return { wrap: false };
+            wrap.click();
+            const dlg = document.querySelector('dialog.geely-expand');
+            return {
+                wrap: true,
+                role: wrap.getAttribute('role'),
+                dialogInBody: !!dlg && dlg.parentElement === document.body,
+                open: !!dlg && dlg.open,
+                hasFullCard: !!(dlg && dlg.querySelector('geely-card')),
+            };
+        })()""")
+    assert got["wrap"] is True, got
+    assert got["role"] == "button", got
+    assert got["dialogInBody"] is True, got
+    assert got["open"] is True, got
+    assert got["hasFullCard"] is True, got


### PR DESCRIPTION
Two card additions, both opt-in and shipping no artwork.

**Bring your own car photo.** The card draws a generic crossover; this adds a `car_image` option so an owner can point it at a photo of their actual car and have it shown instead. The live state is preserved — headlights, tail lights, charge-port light and the open-panel markers are drawn as an overlay *on top* of the image, positioned as percentages (overridable with `car_image_hotspots`) so one coordinate set fits any side-on shot. No images are bundled: the owner supplies a file under `config/www/`, so it survives add-on updates and there's no third-party artwork in the repo. With no `car_image` set, nothing changes — the drawn car is kept exactly as now.

**Tap the car to expand.** On the compact summary card, tapping the car opens the full card in a modal. The dialog is appended to `document.body`, not the card's shadow root — a top-layer modal centres against its containing block, and the dashboard's masonry/section layouts put a `transform` on a card ancestor, which inside the shadow root sends the dialog to a corner; in `document.body` it centres on the viewport. Backdrop-click and Escape dismiss it; it's torn down with the card.

**Why it matters beyond the feature:** it's the clean, general version of a common request, and it means a card customised with a personal image no longer breaks on update — the image lives in the owner's own `www/`, and the machinery is now in the card itself.

**Tests:** browser tests cover a configured image replacing the SVG while keeping the overlay, no-image keeping the drawing, and the summary card's car opening a centred, populated full-card dialog. I verified all three assertions in a real browser as well. README documents both options. Independent of the other open PRs — based on `main`.
