### PR TITLE
Cards: display options (hide name, battery % headline, Parked chip, charge-time format)

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,9 @@ Everything else is optional:
 | `boot:` | by country | `true` labels the tailgate *Boot*, `false` *Trunk* |
 | `rhd:` | by country | `true` draws the driver on the right in the top view, `false` on the left |
 | `name:` | the device name | A different title for this card |
-| `hide_name:` | `false` | `true` removes the vehicle name from the header entirely (the online status dot stays) |
-| `battery_size:` | *unset* | Compact card only. A pixel size (e.g. `26`) shows the battery **percentage as a headline above the range** at that size, instead of small in the top-right - tune it to taste |
+| `hide_name:` | `false` | `true` removes the vehicle name **and the status dot** from the header |
+| `battery_size:` | *unset* | Compact card only. A pixel size (e.g. `26`) shows the battery **percentage as a headline above the range** at that size (with the cabin temperature beside it), instead of small in the top-right - tune it to taste |
+| `battery_bold:` | `true` | Set `false` to draw the battery-% headline in a regular weight instead of bold |
 | `show_parked:` | `false` | Compact card only. `true` adds a **Parked** chip next to Locked while the car is stationary, matching the full card's status |
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Everything else is optional:
 | `hide_name:` | `false` | `true` removes the vehicle name **and the status dot** from the header |
 | `battery_size:` | *unset* | Compact card only. A pixel size (e.g. `26`) shows the battery **percentage as a headline above the range** at that size (with the cabin temperature beside it), instead of small in the top-right - tune it to taste |
 | `battery_bold:` | `true` | Set `false` to draw the battery-% headline in a regular weight instead of bold |
+| `charge_time_format:` | `min` | How **Time to full** reads while charging: `min` (e.g. `249 min`) or `hm` for hours + minutes (e.g. `4h 9m`) |
 | `show_parked:` | `false` | Compact card only. `true` adds a **Parked** chip next to Locked while the car is stationary, matching the full card's status |
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ Everything else is optional:
 | `boot:` | by country | `true` labels the tailgate *Boot*, `false` *Trunk* |
 | `rhd:` | by country | `true` draws the driver on the right in the top view, `false` on the left |
 | `name:` | the device name | A different title for this card |
+| `hide_name:` | `false` | `true` removes the vehicle name from the header entirely (the online status dot stays) |
+| `battery_size:` | *unset* | Compact card only. A pixel size (e.g. `26`) shows the battery **percentage as a headline above the range** at that size, instead of small in the top-right - tune it to taste |
+| `show_parked:` | `false` | Compact card only. `true` adds a **Parked** chip next to Locked while the car is stationary, matching the full card's status |
 
 ```yaml
 type: custom:geely-card

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -1566,6 +1566,7 @@
       const hideName = !!this._config.hide_name;
       const battSize = Number(this._config.battery_size) || 0;  // px, 0 = off
       const showParked = !!this._config.show_parked;
+      const battBold = this._config.battery_bold !== false;  // default bold
 
       const chips = [
         // First, and only while it is true: the compact card falls back to a
@@ -1598,17 +1599,16 @@
           ${this._drivingNotice()}
           <div class="head">
             <div class="title">
-              <i class="dot ${online && online.state === "off" ? "off" : ""}"></i>
-              ${hideName ? "" : esc(this._title())}
+              ${hideName ? "" : `<i class="dot ${online && online.state === "off" ? "off" : ""}"></i>${esc(this._title())}`}
             </div>
             <span class="micro">${[
               battSize ? "" : this._levels(s, batt),
-              inTemp == null ? "" : Math.round(inTemp) + "° in",
+              (battSize || inTemp == null) ? "" : Math.round(inTemp) + "° in",
             ].filter(Boolean).join(" · ")}</span>
           </div>
           <div class="hero">
             <div>
-              ${battSize ? `<div class="battpct" style="font-size:${battSize}px">${batt}%</div>` : ""}
+              ${battSize ? `<div class="battpct" style="font-size:${battSize}px${battBold ? "" : ";font-weight:400"}">${batt}%${inTemp == null ? "" : ` · ${Math.round(inTemp)}°`}</div>` : ""}
               <div class="num n ${OK(s.range) ? "" : "unavail"}">${range}<span class="u">${esc(UNIT(s.range) || "km")}</span></div>
               <div class="micro sub">${esc(this._rangeLabel(s))}</div>
               ${split ? `<div class="micro sub">${esc(split)}</div>` : ""}
@@ -1752,8 +1752,7 @@
           <div class="head">
             <div>
               <div class="title">
-                <i class="dot ${online && online.state === "off" ? "off" : ""}"></i>
-                ${this._config.hide_name ? "" : esc(this._title())}
+                ${this._config.hide_name ? "" : `<i class="dot ${online && online.state === "off" ? "off" : ""}"></i>${esc(this._title())}`}
               </div>
               <div class="status ${s.charging ? "charging" : ""}">${esc(statusLine)}</div>
             </div>
@@ -2224,8 +2223,7 @@
           <div class="head">
             <div>
               <div class="title">
-                <i class="dot ${online && online.state === "off" ? "off" : ""}"></i>
-                ${this._config.hide_name ? "" : esc(this._title())}
+                ${this._config.hide_name ? "" : `<i class="dot ${online && online.state === "off" ? "off" : ""}"></i>${esc(this._title())}`}
               </div>
               <div class="status ${s.charging ? "charging" : ""}">${esc(statusLine)}</div>
             </div>

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -1562,11 +1562,17 @@
       const defrost = this._st("switch.defrost");
       const online = this._st("binary_sensor.connected");
 
+      // Header customisation (all opt-in; unset keeps today's layout).
+      const hideName = !!this._config.hide_name;
+      const battSize = Number(this._config.battery_size) || 0;  // px, 0 = off
+      const showParked = !!this._config.show_parked;
+
       const chips = [
         // First, and only while it is true: the compact card falls back to a
         // "Parked" chip when nothing else applies, which on a moving car was the
         // same contradiction as #25 on its bigger siblings.
         driving && `<span class="chip warn">Driving</span>`,
+        showParked && !driving && `<span class="chip">Parked</span>`,
         s.locked && `<span class="chip ${s.locked.state === "locked" ? "" : "warn"}">
             ${s.locked.state === "locked" ? "Locked" : "Unlocked"}</span>`,
         s.charging && `<span class="chip on">${iconFilled("bolt")} ${power != null ? power.toFixed(1) + " kW" : "Charging"}</span>`,
@@ -1584,6 +1590,8 @@
         .hero .n { font-size:44px; }
         .hero .u { font-size:13px; color: var(--secondary-text-color); margin-left:3px; }
         .hero .sub { margin-top:4px; }
+        .battpct { font-weight:700; color: var(--primary-text-color);
+                   line-height:1.05; margin-bottom:1px; }
         .carwrap { flex:1; max-width:300px; margin-left:auto; }
         </style>
         <div class="shell">
@@ -1591,15 +1599,16 @@
           <div class="head">
             <div class="title">
               <i class="dot ${online && online.state === "off" ? "off" : ""}"></i>
-              ${esc(this._title())}
+              ${hideName ? "" : esc(this._title())}
             </div>
             <span class="micro">${[
-              this._levels(s, batt),
+              battSize ? "" : this._levels(s, batt),
               inTemp == null ? "" : Math.round(inTemp) + "° in",
             ].filter(Boolean).join(" · ")}</span>
           </div>
           <div class="hero">
             <div>
+              ${battSize ? `<div class="battpct" style="font-size:${battSize}px">${batt}%</div>` : ""}
               <div class="num n ${OK(s.range) ? "" : "unavail"}">${range}<span class="u">${esc(UNIT(s.range) || "km")}</span></div>
               <div class="micro sub">${esc(this._rangeLabel(s))}</div>
               ${split ? `<div class="micro sub">${esc(split)}</div>` : ""}
@@ -1744,7 +1753,7 @@
             <div>
               <div class="title">
                 <i class="dot ${online && online.state === "off" ? "off" : ""}"></i>
-                ${esc(this._title())}
+                ${this._config.hide_name ? "" : esc(this._title())}
               </div>
               <div class="status ${s.charging ? "charging" : ""}">${esc(statusLine)}</div>
             </div>
@@ -2052,7 +2061,7 @@
           <div class="head">
             <div class="title">
               <i class="dot ${online && online.state === "off" ? "off" : ""}"></i>
-              <em>${esc(this._title())}</em>
+              <em>${this._config.hide_name ? "" : esc(this._title())}</em>
             </div>
             <span class="temp">${[
               s.battery == null ? "" : Math.round(s.battery) + "%",
@@ -2216,7 +2225,7 @@
             <div>
               <div class="title">
                 <i class="dot ${online && online.state === "off" ? "off" : ""}"></i>
-                ${esc(this._title())}
+                ${this._config.hide_name ? "" : esc(this._title())}
               </div>
               <div class="status ${s.charging ? "charging" : ""}">${esc(statusLine)}</div>
             </div>

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -1792,7 +1792,21 @@
           <div class="grid sec">
             ${this._row("Charger", s.conn)}
             ${this._row("Power", power, { accent: s.charging })}
-            ${this._row("Time to full", this._st("sensor.time_to_full_charge"))}
+            ${this._row("Time to full", this._st("sensor.time_to_full_charge"), {
+              // charge_time_format: "min" (default, e.g. "249 min") or "hm"
+              // (e.g. "4h 9m"). The car reports minutes; "hm" just reshapes it.
+              value: (() => {
+                const st = this._st("sensor.time_to_full_charge");
+                if (!OK(st)) return "—";
+                const fmt = this._config.charge_time_format;
+                if (fmt === "hm" || fmt === "hours" || fmt === "hours_min") {
+                  const mins = Math.round(NUM(st));
+                  if (mins == null || isNaN(mins)) return this._fmt(st);
+                  const h = Math.floor(mins / 60), m = mins % 60;
+                  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+                }
+                return this._fmt(st);
+              })() })}
             ${this._row("Complete at", this._st("sensor.charge_complete"), {
               value: (() => { const st = this._st("sensor.charge_complete");
                 if (!OK(st)) return "—";
@@ -2263,7 +2277,21 @@
           <div class="grid sec">
             ${this._row("Charger", s.conn)}
             ${this._row("Power", power, { accent: s.charging })}
-            ${this._row("Time to full", this._st("sensor.time_to_full_charge"))}
+            ${this._row("Time to full", this._st("sensor.time_to_full_charge"), {
+              // charge_time_format: "min" (default, e.g. "249 min") or "hm"
+              // (e.g. "4h 9m"). The car reports minutes; "hm" just reshapes it.
+              value: (() => {
+                const st = this._st("sensor.time_to_full_charge");
+                if (!OK(st)) return "—";
+                const fmt = this._config.charge_time_format;
+                if (fmt === "hm" || fmt === "hours" || fmt === "hours_min") {
+                  const mins = Math.round(NUM(st));
+                  if (mins == null || isNaN(mins)) return this._fmt(st);
+                  const h = Math.floor(mins / 60), m = mins % 60;
+                  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+                }
+                return this._fmt(st);
+              })() })}
             ${this._row("Complete at", this._st("sensor.charge_complete"), {
               value: (() => { const st = this._st("sensor.charge_complete");
                 if (!OK(st)) return "—";

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -1592,7 +1592,7 @@
         .hero .u { font-size:13px; color: var(--secondary-text-color); margin-left:3px; }
         .hero .sub { margin-top:4px; }
         .battpct { font-weight:700; color: var(--primary-text-color);
-                   line-height:1.05; margin-bottom:1px; }
+                   line-height:1; margin:-4px 0 2px; }
         .carwrap { flex:1; max-width:300px; margin-left:auto; }
         </style>
         <div class="shell">

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -1591,8 +1591,7 @@
         .hero .n { font-size:44px; }
         .hero .u { font-size:13px; color: var(--secondary-text-color); margin-left:3px; }
         .hero .sub { margin-top:4px; }
-        .battpct { font-weight:700; color: var(--primary-text-color);
-                   line-height:1; margin:-4px 0 2px; }
+        .battpct { color: var(--primary-text-color); margin:-8px 0 2px; }
         .carwrap { flex:1; max-width:300px; margin-left:auto; }
         </style>
         <div class="shell">
@@ -1608,7 +1607,7 @@
           </div>
           <div class="hero">
             <div>
-              ${battSize ? `<div class="battpct" style="font-size:${battSize}px${battBold ? "" : ";font-weight:400"}">${batt}%${inTemp == null ? "" : ` · ${Math.round(inTemp)}°`}</div>` : ""}
+              ${battSize ? `<div class="battpct num" style="font-size:${battSize}px${battBold ? ";font-weight:700" : ""}">${batt}%${inTemp == null ? "" : ` · ${Math.round(inTemp)}°`}</div>` : ""}
               <div class="num n ${OK(s.range) ? "" : "unavail"}">${range}<span class="u">${esc(UNIT(s.range) || "km")}</span></div>
               <div class="micro sub">${esc(this._rangeLabel(s))}</div>
               ${split ? `<div class="micro sub">${esc(split)}</div>` : ""}

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -1727,3 +1727,35 @@ def test_battery_bold_can_be_turned_off():
             getComputedStyle(el.shadowRoot.querySelector('.battpct')).fontWeight
         """, cfg={"battery_size": 24, "battery_bold": False})
     assert str(plain) in ("400", "normal"), plain
+
+
+# --------------------------------------------- charge_time_format option ---
+
+_CHARGE_TIME_SCRIPT = r"""(arg) => {
+    const el = document.createElement("geely-card");
+    document.body.appendChild(el);
+    el.setConfig(arg.cfg || {});
+    const hass = window.mkHass({});
+    hass.states["sensor.car_time_to_full_charge"] = {
+        entity_id: "sensor.car_time_to_full_charge", state: arg.mins,
+        attributes: {unit_of_measurement: "min"}};
+    el.hass = hass;
+    const rows = [...el.shadowRoot.querySelectorAll(".row")];
+    const r = rows.find(x => /Time to full/.test(x.textContent));
+    const v = r ? r.querySelector("b").textContent.trim() : null;
+    el.remove();
+    return v;
+}"""
+
+
+def test_charge_time_hours_minutes_format():
+    assert _evaluate(_CHARGE_TIME_SCRIPT,
+                     arg={"mins": "249", "cfg": {"charge_time_format": "hm"}}) == "4h 9m"
+    # under an hour drops the hours part
+    assert _evaluate(_CHARGE_TIME_SCRIPT,
+                     arg={"mins": "45", "cfg": {"charge_time_format": "hm"}}) == "45m"
+
+
+def test_charge_time_defaults_to_minutes():
+    v = _evaluate(_CHARGE_TIME_SCRIPT, arg={"mins": "249", "cfg": {}})
+    assert "249" in v, v   # unchanged from today's minutes reading

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -1660,3 +1660,52 @@ def test_the_compact_card_watches_what_its_head_row_prints():
     compact = src[src.index("class GeelyCardCompact"):src.index("class GeelyCard extends")]
     assert '"sensor.interior_temperature"' in compact, (
         "the compact card prints the cabin temp without watching it")
+
+
+# ------------------------------------------- compact header customisation ---
+
+def test_hide_name_removes_the_title_text():
+    got = _mount("geely-card-compact", """{
+            withName: (el.shadowRoot.querySelector('.title')||{}).textContent
+                       ? el.shadowRoot.querySelector('.title').textContent.trim() : '',
+        }""")
+    assert got["withName"], got  # name present by default
+    got2 = _mount("geely-card-compact", """{
+            title: el.shadowRoot.querySelector('.title').textContent.trim(),
+            dot: !!el.shadowRoot.querySelector('.title .dot'),
+        }""", cfg={"hide_name": True})
+    assert got2["title"] == "", got2       # name gone
+    assert got2["dot"] is True, got2       # online dot kept
+
+
+def test_battery_size_promotes_the_percentage_above_the_range():
+    got = _mount("geely-card-compact", """{
+            battpct: (el.shadowRoot.querySelector('.battpct')||{}).textContent || null,
+            size: el.shadowRoot.querySelector('.battpct')
+                  ? getComputedStyle(el.shadowRoot.querySelector('.battpct')).fontSize : null,
+            microHasPct: /%/.test(el.shadowRoot.querySelector('.head .micro').textContent),
+        }""", cfg={"battery_size": 28})
+    assert got["battpct"] and got["battpct"].endswith("%"), got
+    assert got["size"] == "28px", got            # size is the configured value
+    assert got["microHasPct"] is False, got      # % moved out of the small line
+
+
+def test_no_battery_size_keeps_the_percentage_in_the_small_line():
+    got = _mount("geely-card-compact", """{
+            battpct: !!el.shadowRoot.querySelector('.battpct'),
+            microHasPct: /%/.test(el.shadowRoot.querySelector('.head .micro').textContent),
+        }""")
+    assert got["battpct"] is False, got
+    assert got["microHasPct"] is True, got
+
+
+def test_show_parked_adds_a_parked_chip_beside_locked():
+    got = _mount("geely-card-compact", """
+            [...el.shadowRoot.querySelectorAll('.chips .chip')].map(c => c.textContent.trim())
+        """, cfg={"show_parked": True})
+    assert "Parked" in got and "Locked" in got, got
+    # default: no standalone Parked chip while locked
+    got2 = _mount("geely-card-compact", """
+            [...el.shadowRoot.querySelectorAll('.chips .chip')].map(c => c.textContent.trim())
+        """)
+    assert "Parked" not in got2, got2

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -1675,7 +1675,7 @@ def test_hide_name_removes_the_title_text():
             dot: !!el.shadowRoot.querySelector('.title .dot'),
         }""", cfg={"hide_name": True})
     assert got2["title"] == "", got2       # name gone
-    assert got2["dot"] is True, got2       # online dot kept
+    assert got2["dot"] is False, got2      # status dot removed with the name
 
 
 def test_battery_size_promotes_the_percentage_above_the_range():
@@ -1685,7 +1685,7 @@ def test_battery_size_promotes_the_percentage_above_the_range():
                   ? getComputedStyle(el.shadowRoot.querySelector('.battpct')).fontSize : null,
             microHasPct: /%/.test(el.shadowRoot.querySelector('.head .micro').textContent),
         }""", cfg={"battery_size": 28})
-    assert got["battpct"] and got["battpct"].endswith("%"), got
+    assert got["battpct"] and "%" in got["battpct"], got
     assert got["size"] == "28px", got            # size is the configured value
     assert got["microHasPct"] is False, got      # % moved out of the small line
 
@@ -1709,3 +1709,21 @@ def test_show_parked_adds_a_parked_chip_beside_locked():
             [...el.shadowRoot.querySelectorAll('.chips .chip')].map(c => c.textContent.trim())
         """)
     assert "Parked" not in got2, got2
+
+
+def test_the_battery_headline_carries_the_cabin_temp_beside_the_percent():
+    got = _mount("geely-card-compact", """
+            (el.shadowRoot.querySelector('.battpct')||{}).textContent || ''
+        """, cfg={"battery_size": 24})
+    assert "%" in got and "°" in got, got   # e.g. "84% · 21°"
+
+
+def test_battery_bold_can_be_turned_off():
+    bold = _mount("geely-card-compact", """
+            getComputedStyle(el.shadowRoot.querySelector('.battpct')).fontWeight
+        """, cfg={"battery_size": 24})
+    assert str(bold) in ("700", "bold"), bold
+    plain = _mount("geely-card-compact", """
+            getComputedStyle(el.shadowRoot.querySelector('.battpct')).fontWeight
+        """, cfg={"battery_size": 24, "battery_bold": False})
+    assert str(plain) in ("400", "normal"), plain


### PR DESCRIPTION
Three small, opt-in card header options — all defaulting to today's layout, independent, and composable. Requested by an owner who wanted a tighter compact card.

| option | card | effect |
|---|---|---|
| `hide_name` | all | removes the vehicle name from the header (keeps the online status dot) |
| `battery_size` | compact | a px size (e.g. `26`) that promotes the battery **percentage to a headline above the range** at that size, instead of the small top-right reading — tunable so it sits between "small" and the range figure |
| `show_parked` | compact | adds a **Parked** chip next to Locked while the car is stationary, matching the full card's "Parked · Locked" |

With all three on, the compact header drops the name, shows a large battery % above the range, and reads Parked · Locked in the chips. Unset, nothing changes.

Kept deliberately **separate from the car-image PR (#62)** — that's one coherent feature (bring-your-own image + tap-to-expand); this is header layout, a different concern, so each stays focused and independently reviewable.

Browser tests cover each option and the untouched default; README documents all three. No behaviour change to any command or state — purely layout. Based on `main`.
