### PR TITLE
Fix driving state dropping out: normalise the engine-running separator

### DIFF
--- a/custom_components/geely_connect/__init__.py
+++ b/custom_components/geely_connect/__init__.py
@@ -296,7 +296,10 @@ def _poll_flags(d: dict) -> tuple[bool, bool]:
     # stays on through those stops, so a running car counts as driving even
     # at a standstill. On a trim that never reports it this reduces to the
     # old speed test.
-    engine = str(basic.get("engineStatus", "")).strip().lower()
+    # The new platform reports "engine-running" (hyphen); the legacy set uses
+    # "engine_running". Normalise so the ready/running state matches on both -
+    # without this a moving car whose speed momentarily reads 0 flips to parked.
+    engine = str(basic.get("engineStatus", "")).strip().lower().replace("-", "_")
     running = engine in _ENGINE_RUNNING
     return charging, (moving or running)
 

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -1050,7 +1050,10 @@
       // No unit needed here: "is it moving" is the same question in mph.
       if (speed != null && speed > 0) return true;
       const eng = this._st("sensor.engine_state");
-      const raw = eng ? String(eng.state).trim().toLowerCase() : "";
+      // "engine-running" (new platform) and "engine_running" (legacy) both mean
+      // driving; normalise the separator so a running car stays "driving" even
+      // when the speed field momentarily reads 0 between the car's uploads.
+      const raw = eng ? String(eng.state).trim().toLowerCase().replace(/-/g, "_") : "";
       return DRIVING_STATES.has(raw);
     }
 

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -399,6 +399,16 @@ def test_a_car_stopped_at_a_light_is_still_driving():
         assert got["live"] in ([], ["refresh"]), (tag, got["live"])
 
 
+def test_the_new_platforms_hyphenated_engine_value_still_reads_as_driving():
+    """The real new-platform value is "engine-running" (hyphen); the driving set
+    uses "engine_running". Without normalising the separator, a moving car whose
+    speed field momentarily reads 0 between uploads flips to Parked - which is
+    exactly the flicker owners saw. Speed 0 + engine-running must stay Driving."""
+    for tag in ("geely-card", "geely-card-compact", "geely-card-mini"):
+        got = _mount(tag, _driving_probe(), speed="0", engine="engine-running")
+        assert "Driving" in got["text"], (tag, got)
+
+
 def test_a_trim_that_never_reports_an_engine_state_falls_back_to_speed():
     """`engine_state` is absent on some trims, where the test has to reduce to
     the old speed check rather than concluding "parked" for ever."""

--- a/tests/test_polling_logic.py
+++ b/tests/test_polling_logic.py
@@ -73,7 +73,10 @@ def test_driving_is_any_positive_speed():
 
 def test_a_running_car_at_a_standstill_still_counts_as_driving():
     m = _coordinator_module()
-    for word in ("engine_running", "running", "ENGINE_RUNNING", "on", "1", 1):
+    # "engine-running" is the real new-platform value (hyphen); it must count
+    # the same as the legacy "engine_running", or a moving car whose speed field
+    # momentarily reads 0 flips to parked.
+    for word in ("engine_running", "engine-running", "running", "ENGINE_RUNNING", "on", "1", 1):
         assert m._poll_flags(_status(speed="0", engine=word))[1] is True, word
 
 


### PR DESCRIPTION
A car that is actually driving keeps flipping to **Parked** — on the card and in the poll loop — and a manual sync briefly shows Driving again.

**Cause:** the engine/ready state is meant to hold "driving" through the moments speed reads 0 (every light — and on the new platform the cloud snapshot's speed field simply *lags to 0* between the car's own uploads). It wasn't holding, because the value is tested against a set spelled `engine_running`, while the new platform reports it as **`engine-running`** (hyphen). The hyphen never matched, so both the card's `_isDriving` and the coordinator's `_poll_flags` fell back to **speed alone** and dropped at every 0.

Observed live on a moving car: `engineStatus` held `engine-running` for the whole trip while `speed` read `53 → 0 → 66 → 0 → 68` — and the card followed the zeros to Parked.

**Fix:** both the card and the poller normalise the separator (`-` → `_`) before the membership test, so `engine-running` and `engine_running` are equivalent. A genuinely off engine still reads parked; a trim with no engine state still falls back to speed. No other behaviour changes.

The existing tests missed this because they used the underscore spelling — both suites now also assert the real hyphenated value keeps a standstill car Driving.

Independent of the other open PRs; based on `main`.
