### PR TITLE
Blueprint + automation: live lock-screen charging countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,9 +639,9 @@ automation:
 
 Other smart behaviour: **long-term statistics** (battery, range, consumption,
 pressures feed HA statistics + the Energy dashboard) and **ready-made
-Blueprints** in `blueprints/` (charging complete, low battery, door/trunk left
-open, tire pressure out of range, left unlocked away from home, pre-condition
-climate before departure).
+Blueprints** in `blueprints/` (charging complete, a live lock-screen charging
+countdown, low battery, door/trunk left open, tire pressure out of range, left
+unlocked away from home, pre-condition climate before departure).
 
 ---
 
@@ -662,7 +662,9 @@ one entry at a time through the automation editor's ⋮ → **Edit in YAML**.
 Replace `notify.mobile_app_your_phone` with your own notifier.
 
 - **`automations/charging.yaml`** - charge finished, charge nearly finished
-  (uses the Charge Complete timestamp), low battery, and "you forgot to plug in".
+  (uses the Charge Complete timestamp), a live lock-screen charging countdown
+  (ongoing notification with a ticking timer, Android companion app), low
+  battery, and "you forgot to plug in".
 - **`automations/security.yaml`** - something left open, left unlocked after
   leaving, windows open with rain forecast, and a bedtime check.
 - **`automations/comfort-and-maintenance.yaml`** - weekday pre-heat, hot-cabin

--- a/automations/charging.yaml
+++ b/automations/charging.yaml
@@ -206,3 +206,84 @@
           ({{ states('sensor.my_geely_ex5_electric_range') }} km) and the
           cable is not connected.
   mode: single
+
+- id: geely_charging_countdown_notification
+  alias: "Geely: charging countdown (lock-screen)"
+  description: >-
+    A single ongoing lock-screen notification while the car charges: a live
+    countdown timer, the finish time and charging power, and a charging icon
+    pinned in the status bar. It refreshes silently and is replaced by a
+    one-line summary when the session ends.
+
+    Android companion app only for the full effect - the ticking timer, the
+    status-bar pin and "alert once" are Android notification features. On iOS
+    you still get a notification that refreshes and clears, without the timer.
+  triggers:
+    - trigger: state
+      entity_id: sensor.my_geely_ex5_charger_connection
+    - trigger: state
+      entity_id: sensor.my_geely_ex5_charge_complete
+  actions:
+    - choose:
+        # Charging, with a finish time: post / refresh the countdown. The timer
+        # counts DOWN to Charge Complete - an absolute clock time, so the phone
+        # ticks it smoothly between polls. Do NOT anchor it to Time To Full
+        # Charge: that is the figure the car reported at the last poll and does
+        # not tick down between them, so it would freeze mid-count.
+        - conditions:
+            - condition: state
+              entity_id: sensor.my_geely_ex5_charger_connection
+              state: "Charging"
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.my_geely_ex5_charge_complete') }}
+          sequence:
+            - action: notify.mobile_app_your_phone
+              data:
+                title: "🔌 Charging"
+                message: >-
+                  Ready by
+                  {{ as_timestamp(states('sensor.my_geely_ex5_charge_complete'),
+                  0) | timestamp_custom('%-I:%M %p', true) }}
+                  · {{ states('sensor.my_geely_ex5_charging_power') }} kW
+                data:
+                  tag: geely_charging
+                  # Android freezes a channel's importance once it is created.
+                  # If you change "importance" below, also rename this channel.
+                  channel: Car charging
+                  importance: default    # TUNE: "low" hides it from the lock screen
+                  alert_once: true        # sound once at start, silent refreshes
+                  persistent: true
+                  sticky: true
+                  visibility: public
+                  notification_icon: mdi:ev-station
+                  color: "#43A047"
+                  chronometer: true
+                  chronometer_countdown: true
+                  when: >-
+                    {{ as_timestamp(states('sensor.my_geely_ex5_charge_complete'),
+                    0) | int }}
+        # Just left "Charging": a one-shot summary carrying the same tag
+        # overwrites the pinned countdown, so there is no separate "clear" step
+        # to race with the estimate blinking to unknown at the end of a session.
+        - conditions:
+            - condition: template
+              value_template: >-
+                {{ trigger.entity_id
+                == 'sensor.my_geely_ex5_charger_connection'
+                and trigger.from_state is not none
+                and trigger.from_state.state == 'Charging' }}
+          sequence:
+            - action: notify.mobile_app_your_phone
+              data:
+                title: "✅ Charging stopped"
+                message: >-
+                  {{ states('sensor.my_geely_ex5_electric_range') }} km of range.
+                data:
+                  tag: geely_charging
+                  channel: Car charging
+                  sticky: false
+                  notification_icon: mdi:ev-station
+                  color: "#43A047"
+  mode: queued
+  max: 10

--- a/automations/charging.yaml
+++ b/automations/charging.yaml
@@ -212,8 +212,9 @@
   description: >-
     A single ongoing lock-screen notification while the car charges: a live
     countdown timer, the finish time and charging power, and a charging icon
-    pinned in the status bar. It refreshes silently and is replaced by a
-    one-line summary when the session ends.
+    pinned in the status bar. It refreshes silently; at a true full it is
+    replaced by a "charged" alert on its own channel (so you can give that a
+    distinct sound), and an early unplug clears it quietly instead.
 
     Android companion app only for the full effect - the ticking timer, the
     status-bar pin and "alert once" are Android notification features. On iOS
@@ -223,13 +224,46 @@
       entity_id: sensor.my_geely_ex5_charger_connection
     - trigger: state
       entity_id: sensor.my_geely_ex5_charge_complete
+    # Drives the "charged" alert off the battery reaching full, held briefly so
+    # a single odd reading can't fire it. TUNE: 99.5 catches a 100 that reads a
+    # touch under; raise/lower to taste.
+    - trigger: numeric_state
+      entity_id: sensor.my_geely_ex5_battery
+      above: 99.5
+      for: "00:00:20"
   actions:
     - choose:
-        # Charging, with a finish time: post / refresh the countdown. The timer
-        # counts DOWN to Charge Complete - an absolute clock time, so the phone
-        # ticks it smoothly between polls. Do NOT anchor it to Time To Full
-        # Charge: that is the figure the car reported at the last poll and does
-        # not tick down between them, so it would freeze mid-count.
+        # TRUE full: clear the countdown, then a "charged" alert on its OWN
+        # channel + high importance, so a charge-finished sound (set per channel
+        # in Android) plays here and never on the countdown. Only the battery
+        # trigger is numeric_state, so this fires once at full - not on an early
+        # unplug.
+        - conditions:
+            - condition: template
+              value_template: "{{ trigger.platform == 'numeric_state' }}"
+          sequence:
+            - action: notify.mobile_app_your_phone
+              data:
+                message: clear_notification
+                data:
+                  tag: geely_charging
+            - action: notify.mobile_app_your_phone
+              data:
+                title: "✅ Charged"
+                message: >-
+                  {{ states('sensor.my_geely_ex5_electric_range') }} km of range.
+                data:
+                  tag: geely_charge_done
+                  channel: Car charging done
+                  importance: high
+                  sticky: false
+                  notification_icon: mdi:ev-station
+                  color: "#43A047"
+                  clickAction: /lovelace/car
+        # Charging, not yet full: post / refresh the countdown. The timer counts
+        # DOWN to Charge Complete - an absolute clock time, so the phone ticks it
+        # smoothly between polls. Do NOT anchor it to Time To Full Charge: that
+        # is the figure the car reported at the last poll and does not tick down.
         - conditions:
             - condition: state
               entity_id: sensor.my_geely_ex5_charger_connection
@@ -237,6 +271,9 @@
             - condition: template
               value_template: >-
                 {{ has_value('sensor.my_geely_ex5_charge_complete') }}
+            - condition: template
+              value_template: >-
+                {{ (states('sensor.my_geely_ex5_battery') | float(0)) < 99.5 }}
           sequence:
             - action: notify.mobile_app_your_phone
               data:
@@ -267,9 +304,8 @@
                   # at a view showing the full custom:geely-card and the tap
                   # lands on the full card. Remove the line to just open the app.
                   clickAction: /lovelace/car
-        # Just left "Charging": a one-shot summary carrying the same tag
-        # overwrites the pinned countdown, so there is no separate "clear" step
-        # to race with the estimate blinking to unknown at the end of a session.
+        # Stopped before full (early unplug): a one-shot summary carrying the
+        # countdown tag + channel replaces the pin without a sound (alert_once).
         - conditions:
             - condition: template
               value_template: >-
@@ -277,15 +313,22 @@
                 == 'sensor.my_geely_ex5_charger_connection'
                 and trigger.from_state is not none
                 and trigger.from_state.state == 'Charging' }}
+            - condition: template
+              value_template: >-
+                {{ (states('sensor.my_geely_ex5_battery') | float(0)) < 99.5 }}
           sequence:
             - action: notify.mobile_app_your_phone
               data:
-                title: "✅ Charging stopped"
+                title: "🔌 Charging stopped"
                 message: >-
-                  {{ states('sensor.my_geely_ex5_electric_range') }} km of range.
+                  Stopped at
+                  {{ states('sensor.my_geely_ex5_battery') | float(0) | round | int }}%
+                  · {{ states('sensor.my_geely_ex5_electric_range') }} km
                 data:
                   tag: geely_charging
                   channel: Car charging
+                  importance: default
+                  alert_once: true
                   sticky: false
                   notification_icon: mdi:ev-station
                   color: "#43A047"

--- a/automations/charging.yaml
+++ b/automations/charging.yaml
@@ -263,6 +263,10 @@
                   when: >-
                     {{ as_timestamp(states('sensor.my_geely_ex5_charge_complete'),
                     0) | int }}
+                  # Tapping the notification opens this Lovelace path. Point it
+                  # at a view showing the full custom:geely-card and the tap
+                  # lands on the full card. Remove the line to just open the app.
+                  clickAction: /lovelace/car
         # Just left "Charging": a one-shot summary carrying the same tag
         # overwrites the pinned countdown, so there is no separate "clear" step
         # to race with the estimate blinking to unknown at the end of a session.
@@ -285,5 +289,6 @@
                   sticky: false
                   notification_icon: mdi:ev-station
                   color: "#43A047"
+                  clickAction: /lovelace/car
   mode: queued
   max: 10

--- a/blueprints/automation/geely_connect/charging_countdown_notification.yaml
+++ b/blueprints/automation/geely_connect/charging_countdown_notification.yaml
@@ -4,8 +4,9 @@ blueprint:
     A single ongoing notification that stays on your phone's lock screen while
     the car charges: a live countdown timer, the finish time and the charging
     power, plus a persistent charging icon in the status bar. It refreshes
-    itself silently as the estimate changes and is replaced by a one-line
-    summary when the session ends.
+    itself silently as the estimate changes. When the battery reaches full it is
+    replaced by a "charged" alert on its own channel (so you can give that a
+    distinct sound); an early unplug clears it quietly instead.
 
 
     Android (Home Assistant Companion app) only for the full effect - the
@@ -37,6 +38,15 @@ blueprint:
         entity:
           domain: sensor
           device_class: timestamp
+    battery_sensor:
+      name: Battery sensor
+      description: >
+        The drive battery %, used to fire the "charged" alert at a true full -
+        not merely when charging stops - so an early unplug never triggers it.
+      selector:
+        entity:
+          domain: sensor
+          device_class: battery
     notify_target:
       name: Notify service
       description: >
@@ -57,8 +67,8 @@ blueprint:
     range_sensor:
       name: Range sensor (optional)
       description: >
-        Shown when charging stops, e.g. "292 km range". Leave blank to leave it
-        off.
+        Shown on the "charged" alert, e.g. "292 km range". Leave blank to leave
+        it off.
       default: ""
       selector:
         entity:
@@ -79,7 +89,7 @@ blueprint:
       selector:
         text:
     channel_name:
-      name: Notification channel
+      name: Countdown channel
       description: >
         Android groups notifications by channel and remembers each channel's
         settings. If you change the importance below, also change this name:
@@ -88,8 +98,18 @@ blueprint:
       default: Car charging
       selector:
         text:
+    complete_channel:
+      name: Charge-finished channel
+      description: >
+        A SEPARATE channel for the "charged" alert, so you can give it its own
+        sound in Android (long-press the notification -> the channel -> Sound)
+        without the ongoing countdown ever making that sound. Keep it different
+        from the countdown channel above.
+      default: Car charging done
+      selector:
+        text:
     importance:
-      name: Importance
+      name: Countdown importance
       description: >
         "default" shows on the lock screen (recommended). "low" is quieter, but
         Android hides low-importance notifications from the lock screen. "high"
@@ -101,34 +121,88 @@ blueprint:
             - default
             - low
             - high
+    full_level:
+      name: Full at (%)
+      description: >
+        Battery % that counts as fully charged and fires the "charged" alert.
+        99.5 catches a 100 that momentarily reads a touch under.
+      default: 99.5
+      selector:
+        number:
+          min: 80
+          max: 100
+          step: 0.5
+          unit_of_measurement: "%"
+          mode: box
 
 variables:
   connection_entity: !input connection_sensor
   complete_entity: !input charge_complete_sensor
+  battery_entity: !input battery_sensor
   power_entity: !input power_sensor
   range_entity: !input range_sensor
+  full_v: !input full_level
+  not_full: "{{ (states(battery_entity) | float(0)) < full_v }}"
+  batt_now: "{{ states(battery_entity) | float(0) | round | int }}"
   finish: >-
     {{ as_timestamp(states(complete_entity), 0) | timestamp_custom('%-I:%M %p', true) }}
   power_txt: >-
     {% if power_entity not in [none, ''] and has_value(power_entity) %} · {{ states(power_entity) }} {{ state_attr(power_entity, 'unit_of_measurement') or 'kW' }}{% endif %}
-  range_txt: >-
-    {% if range_entity not in [none, ''] and has_value(range_entity) %}{{ states(range_entity) }} km range{% else %}Charging has stopped.{% endif %}
+  full_txt: >-
+    {% if range_entity not in [none, ''] and has_value(range_entity) %}{{ states(range_entity) }} km range{% else %}Fully charged.{% endif %}
+  stop_txt: >-
+    Stopped at {{ batt_now }}%{% if range_entity not in [none, ''] and has_value(range_entity) %} · {{ states(range_entity) }} km{% endif %}
 
 trigger:
   - platform: state
     entity_id: !input connection_sensor
   - platform: state
     entity_id: !input charge_complete_sensor
+  # Drives the "charged" alert off the battery reaching full, held briefly so a
+  # single odd reading can't fire it.
+  - platform: numeric_state
+    entity_id: !input battery_sensor
+    above: !input full_level
+    for:
+      seconds: 20
 
 action:
   - choose:
-      # ---- Charging, with a finish time: post / refresh the countdown -------
+      # ---- TRUE full: clear the countdown, then the "charged" alert ---------
+      # Only the battery trigger has platform numeric_state, so this fires once
+      # at full and never on an early unplug.
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.platform == 'numeric_state' }}"
+        sequence:
+          - service: !input notify_target
+            data:
+              message: clear_notification
+              data:
+                tag: geely_charging
+          - service: !input notify_target
+            data:
+              title: "✅ Charged"
+              message: "{{ full_txt }}"
+              data:
+                # Own channel + high importance so a charge-finished sound (set
+                # per channel in Android) plays here and never on the countdown.
+                tag: geely_charge_done
+                channel: !input complete_channel
+                importance: high
+                sticky: false
+                notification_icon: !input icon
+                color: "#43A047"
+                clickAction: !input dashboard_path
+      # ---- Charging, not yet full: post / refresh the countdown ------------
       - conditions:
           - condition: state
             entity_id: !input connection_sensor
             state: "Charging"
           - condition: template
             value_template: "{{ has_value(complete_entity) }}"
+          - condition: template
+            value_template: "{{ not_full }}"
         sequence:
           - service: !input notify_target
             data:
@@ -148,29 +222,32 @@ action:
                 chronometer_countdown: true
                 when: "{{ as_timestamp(states(complete_entity), 0) | int }}"
                 clickAction: !input dashboard_path
-      # ---- Just left "Charging": one summary that replaces the pin ----------
-      # A one-shot message with the same tag overwrites the pinned countdown,
-      # so there is no separate "clear" step to race with the estimate blinking
-      # to unknown at the very end of a session.
+      # ---- Stopped before full (early unplug): quiet replace ----------------
+      # Reuses the countdown tag + channel so it swaps the pin without a sound.
       - conditions:
           - condition: template
             value_template: >-
               {{ trigger.entity_id == connection_entity
                  and trigger.from_state is not none
                  and trigger.from_state.state == 'Charging' }}
+          - condition: template
+            value_template: "{{ not_full }}"
         sequence:
           - service: !input notify_target
             data:
-              title: "✅ Charging stopped"
-              message: "{{ range_txt }}"
+              title: "🔌 Charging stopped"
+              message: "{{ stop_txt }}"
               data:
                 tag: geely_charging
                 channel: !input channel_name
                 importance: !input importance
+                alert_once: true
                 sticky: false
                 notification_icon: !input icon
                 color: "#43A047"
                 clickAction: !input dashboard_path
+  # No default: the last "charged"/"stopped" message stays put - a stray trigger
+  # while idle can never wipe it, nor race the estimate blinking to unknown.
 
 mode: queued
 max: 10

--- a/blueprints/automation/geely_connect/charging_countdown_notification.yaml
+++ b/blueprints/automation/geely_connect/charging_countdown_notification.yaml
@@ -1,0 +1,165 @@
+blueprint:
+  name: Geely Connect - Charging countdown (live lock-screen notification)
+  description: >
+    A single ongoing notification that stays on your phone's lock screen while
+    the car charges: a live countdown timer, the finish time and the charging
+    power, plus a persistent charging icon in the status bar. It refreshes
+    itself silently as the estimate changes and is replaced by a one-line
+    summary when the session ends.
+
+
+    Android (Home Assistant Companion app) only for the full effect - the
+    ticking timer, the pinned status-bar icon and the "alert once" behaviour are
+    all Android notification features. On iOS you still get a notification that
+    refreshes and clears, just without the live timer or the ongoing pin.
+
+
+    The countdown is anchored to the **Charge Complete** timestamp, not to Time
+    To Full Charge. Charge Complete is an absolute clock time, so the phone can
+    tick it down smoothly between polls; Time To Full is only the figure from
+    the last poll and would freeze between them.
+  domain: automation
+  input:
+    connection_sensor:
+      name: Charger connection sensor
+      description: >
+        The car's Charger Connection sensor - the one that reads "Charging"
+        while a session is running (sensor.<your_car>_charger_connection).
+      selector:
+        entity:
+          domain: sensor
+    charge_complete_sensor:
+      name: Charge Complete sensor
+      description: >
+        The computed finish-time sensor (sensor.<your_car>_charge_complete).
+        The countdown counts down to this.
+      selector:
+        entity:
+          domain: sensor
+          device_class: timestamp
+    notify_target:
+      name: Notify service
+      description: >
+        Your phone's notify service, e.g. notify.mobile_app_pixel_9. It must be
+        a Home Assistant Companion app device for the live countdown.
+      default: notify.notify
+      selector:
+        text:
+    power_sensor:
+      name: Charging power sensor (optional)
+      description: >
+        Added to the message, e.g. "6.8 kW". Leave blank to leave it off.
+      default: ""
+      selector:
+        entity:
+          domain: sensor
+          device_class: power
+    range_sensor:
+      name: Range sensor (optional)
+      description: >
+        Shown when charging stops, e.g. "292 km range". Leave blank to leave it
+        off.
+      default: ""
+      selector:
+        entity:
+          domain: sensor
+    icon:
+      name: Status-bar icon
+      description: The small icon pinned in the status bar while charging.
+      default: mdi:ev-station
+      selector:
+        icon:
+    channel_name:
+      name: Notification channel
+      description: >
+        Android groups notifications by channel and remembers each channel's
+        settings. If you change the importance below, also change this name:
+        Android freezes a channel's importance once it exists and will not raise
+        or lower it, so a fresh name is the only way to apply the new level.
+      default: Car charging
+      selector:
+        text:
+    importance:
+      name: Importance
+      description: >
+        "default" shows on the lock screen (recommended). "low" is quieter, but
+        Android hides low-importance notifications from the lock screen. "high"
+        also pops a heads-up when the channel is first created.
+      default: default
+      selector:
+        select:
+          options:
+            - default
+            - low
+            - high
+
+variables:
+  connection_entity: !input connection_sensor
+  complete_entity: !input charge_complete_sensor
+  power_entity: !input power_sensor
+  range_entity: !input range_sensor
+  finish: >-
+    {{ as_timestamp(states(complete_entity), 0) | timestamp_custom('%-I:%M %p', true) }}
+  power_txt: >-
+    {% if power_entity not in [none, ''] and has_value(power_entity) %} · {{ states(power_entity) }} {{ state_attr(power_entity, 'unit_of_measurement') or 'kW' }}{% endif %}
+  range_txt: >-
+    {% if range_entity not in [none, ''] and has_value(range_entity) %}{{ states(range_entity) }} km range{% else %}Charging has stopped.{% endif %}
+
+trigger:
+  - platform: state
+    entity_id: !input connection_sensor
+  - platform: state
+    entity_id: !input charge_complete_sensor
+
+action:
+  - choose:
+      # ---- Charging, with a finish time: post / refresh the countdown -------
+      - conditions:
+          - condition: state
+            entity_id: !input connection_sensor
+            state: "Charging"
+          - condition: template
+            value_template: "{{ has_value(complete_entity) }}"
+        sequence:
+          - service: !input notify_target
+            data:
+              title: "🔌 Charging"
+              message: "Ready by {{ finish }}{{ power_txt }}"
+              data:
+                tag: geely_charging
+                channel: !input channel_name
+                importance: !input importance
+                alert_once: true       # sound once at start, silent refreshes
+                persistent: true       # pinned - not swipeable while charging
+                sticky: true           # survives a tap
+                visibility: public     # full content on the lock screen
+                notification_icon: !input icon
+                color: "#43A047"
+                chronometer: true
+                chronometer_countdown: true
+                when: "{{ as_timestamp(states(complete_entity), 0) | int }}"
+      # ---- Just left "Charging": one summary that replaces the pin ----------
+      # A one-shot message with the same tag overwrites the pinned countdown,
+      # so there is no separate "clear" step to race with the estimate blinking
+      # to unknown at the very end of a session.
+      - conditions:
+          - condition: template
+            value_template: >-
+              {{ trigger.entity_id == connection_entity
+                 and trigger.from_state is not none
+                 and trigger.from_state.state == 'Charging' }}
+        sequence:
+          - service: !input notify_target
+            data:
+              title: "✅ Charging stopped"
+              message: "{{ range_txt }}"
+              data:
+                tag: geely_charging
+                channel: !input channel_name
+                importance: !input importance
+                sticky: false
+                notification_icon: !input icon
+                color: "#43A047"
+
+mode: queued
+max: 10

--- a/blueprints/automation/geely_connect/charging_countdown_notification.yaml
+++ b/blueprints/automation/geely_connect/charging_countdown_notification.yaml
@@ -69,6 +69,15 @@ blueprint:
       default: mdi:ev-station
       selector:
         icon:
+    dashboard_path:
+      name: Open on tap (dashboard path)
+      description: >
+        Where tapping the notification goes, e.g. /lovelace/car. Point it at a
+        view that shows the full `custom:geely-card` and the tap lands straight
+        on the full card. Leave blank to just open the app.
+      default: ""
+      selector:
+        text:
     channel_name:
       name: Notification channel
       description: >
@@ -138,6 +147,7 @@ action:
                 chronometer: true
                 chronometer_countdown: true
                 when: "{{ as_timestamp(states(complete_entity), 0) | int }}"
+                clickAction: !input dashboard_path
       # ---- Just left "Charging": one summary that replaces the pin ----------
       # A one-shot message with the same tag overwrites the pinned countdown,
       # so there is no separate "clear" step to race with the estimate blinking
@@ -160,6 +170,7 @@ action:
                 sticky: false
                 notification_icon: !input icon
                 color: "#43A047"
+                clickAction: !input dashboard_path
 
 mode: queued
 max: 10


### PR DESCRIPTION
Adds a **live charging countdown** that stays on the phone's lock screen while the car charges:

- a **ticking countdown timer** (Android chronometer)
- the **finish time** and **charging power** on the message line
- a **charging icon pinned in the status bar** while the session runs
- it **refreshes itself silently** as the estimate changes, and is replaced by a one-line "✅ stopped — XXX km range" summary when charging ends

### What's here
Shipped both ways, matching the repo's existing pattern (raw automation + mirrored blueprint):

- `blueprints/automation/geely_connect/charging_countdown_notification.yaml` — inputs for the connection sensor, Charge Complete sensor, notify service, optional power/range sensors, status-bar icon, channel name and importance.
- a fifth entry in `automations/charging.yaml` for the copy-paste crowd.
- two README lines.

### Design notes (why it's built this way)
- **Anchored to Charge Complete, not Time To Full.** The countdown counts down to the absolute `charge_complete` timestamp, so the phone ticks it smoothly between polls — the same reasoning your existing "almost charged" automation already documents for that sensor. Time To Full is the figure from the last poll and would freeze mid-count.
- **No explicit "clear" step.** The stop-summary reuses the same `tag`, so it overwrites the pinned countdown. That avoids a race with the estimate blinking to `unknown` right at the end of a session (which `automations/charging.yaml` already warns about) — a `clear_notification` there would fight the blink and flicker.
- **`importance: default`** so it actually reaches the lock screen — Android hides low-importance notifications from it. **`alert_once`** keeps the refreshes silent after the first alert. The channel input carries a note that Android freezes a channel's importance once created, so changing importance needs a fresh channel name.
- **Android companion app** for the full effect (timer, pin, `alert_once`); iOS still gets a notification that refreshes and clears, just without the live timer.

### Testing
`tests/test_shipped_yaml.py` passes — the blueprint loads under HA's `BLUEPRINT_SCHEMA`, the automation is structurally sound, and `notify` isn't a car-command domain so the back-to-back-command guard is unaffected. Also verified the blueprint substitutes to a valid automation with real inputs (triggers, notify target, and all chronometer/channel/icon keys resolve; `when` stays a template for HA to render live).

Running live on my own EX2 (new EM/Zeekr platform) — screenshot: pinned status-bar icon + a lock-screen countdown reading "🔌 Charging · 3:32:54 / Ready by 12:21 PM · 6.8 kW".