### PR TITLE
Auto-derive the new-platform x-vin (verified against the gateway)

### DIFF
--- a/custom_components/geely_connect/config_flow.py
+++ b/custom_components/geely_connect/config_flow.py
@@ -165,6 +165,9 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._platform_default: str | None = None
         self._zeekr_hf_token: str | None = None
         self._zeekr_password: str | None = None
+        # The logged-in client from the login step, reused in _finish_zeekr to
+        # verify a derived x-vin against the gateway before storing it.
+        self._zeekr_client: Any = None
         # Set when this flow is a re-auth. We update the existing entry's
         # token instead of creating a new one in that case.
         self._reauth_entry: config_entries.ConfigEntry | None = None
@@ -520,6 +523,7 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 client = await self.hass.async_add_executor_job(
                     _zeekr_login_password, email, user_input["password"], self._country_code)
+                self._zeekr_client = client
                 self._zeekr_tokens = (client.access_token or "", client.refresh_token or "")
                 self._zeekr_hf_token = client.hf_token
                 self._zeekr_password = (user_input["password"]
@@ -612,6 +616,29 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         enc_password = await self.hass.async_add_executor_job(
             password_encrypt, self.hass, self._zeekr_password or "")
 
+        # Auto-derive the new-platform x-vin from the VIN where the app build is
+        # known, verifying the gateway accepts it before storing. The
+        # owner-supplied `zeekr_enc_vin` option still overrides, and stays the
+        # fallback when no known build matches (nothing is stored then, so the
+        # entry behaves exactly as before this change). Mechanism per PR #57;
+        # the material is public app package data, not an account credential.
+        existing_x_vin = ""
+        if self._reauth_entry is not None:
+            existing_x_vin = (
+                self._reauth_entry.options.get(CONF_ZEEKR_ENC_VIN)
+                or self._reauth_entry.data.get(CONF_ZEEKR_ENC_VIN) or "")
+        enc_vin = existing_x_vin
+        if not enc_vin and self._zeekr_client is not None:
+            try:
+                enc_vin = await self.hass.async_add_executor_job(
+                    self._zeekr_client.probe_x_vin, vin) or ""
+            except Exception:  # noqa: BLE001 - derivation is best-effort only
+                _LOGGER.debug("x-vin auto-derivation failed; "
+                              "falling back to the manual option", exc_info=True)
+                enc_vin = ""
+            if enc_vin:
+                _LOGGER.info("derived a working new-platform x-vin for this vehicle")
+
         if self._reauth_entry is not None:
             entry = self._reauth_entry
             previous_email = entry.data.get(CONF_EMAIL) or ""
@@ -634,6 +661,8 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # must be re-pointed at the picked vehicle + its metadata.
             new_data[CONF_VIN] = vin
             new_data.update(vehicle_metadata(vehicle))
+            if enc_vin:
+                new_data[CONF_ZEEKR_ENC_VIN] = enc_vin
             # The legacy-only credentials are meaningless on the new platform
             # and their presence sent setup down the dead legacy path (a
             # hybrid entry: legacy keys + zeekr tokens + no platform marker).
@@ -673,6 +702,7 @@ class GeelyIntlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_ZEEKR_HF_TOKEN:      self._zeekr_hf_token or "",
                 CONF_ZEEKR_HF_EXPIRY:     int(time.time()) + 172800,
                 CONF_ZEEKR_PASSWORD:      enc_password,
+                CONF_ZEEKR_ENC_VIN:       enc_vin,
                 **metadata,
                 CONF_PRESSURE_UNIT:       self._pressure_unit,
                 CONF_POLL_MODE:           self._poll_mode,

--- a/custom_components/geely_connect/strings.json
+++ b/custom_components/geely_connect/strings.json
@@ -82,7 +82,7 @@
           "poll_mode": "Polling mode",
           "pressure_unit": "Tire pressure unit",
           "full_exposure": "Expose every raw field (adds ~180 diagnostic entities)",
-          "zeekr_enc_vin": "Vehicle token for the new platform (x-vin) - advanced, leave blank unless you have it"
+          "zeekr_enc_vin": "Vehicle token for the new platform (x-vin) - advanced. Usually derived automatically at setup; set this only to override it, or if your app build is not yet known"
         }
       }
     }

--- a/custom_components/geely_connect/translations/en.json
+++ b/custom_components/geely_connect/translations/en.json
@@ -82,7 +82,7 @@
           "poll_mode": "Polling mode",
           "pressure_unit": "Tire pressure unit",
           "full_exposure": "Expose every raw field (adds ~180 diagnostic entities)",
-          "zeekr_enc_vin": "Vehicle token for the new platform (x-vin) - advanced, leave blank unless you have it"
+          "zeekr_enc_vin": "Vehicle token for the new platform (x-vin) - advanced. Usually derived automatically at setup; set this only to override it, or if your app build is not yet known"
         }
       }
     }

--- a/custom_components/geely_connect/zeekr_client.py
+++ b/custom_components/geely_connect/zeekr_client.py
@@ -941,10 +941,14 @@ class ZeekrClient:
         gateway accepts, or "" if none of the known app builds match.
 
         Each candidate is verified with a read-only, x-vin-addressed call (the
-        capability catalogue): a wrong x-vin is rejected by the gateway and
-        raises, so only a value the gateway resolves to this vehicle is
-        returned. Restores the client's previous x-vin on the way out, so a
-        failed probe never disturbs a value already in use.
+        capability catalogue). Acceptance is POSITIVE, not merely "did not
+        raise": a candidate is kept only if the call returns a NON-EMPTY
+        catalogue, i.e. the gateway resolved the x-vin to a real vehicle. A
+        wrong x-vin is rejected with HTTP 400 `079025 "Decrypt X-VIN failed"`
+        (verified live against a real car), which raises; and a hypothetical
+        non-raising empty response is not accepted either. Restores the
+        client's previous x-vin on the way out, so a failed probe never
+        disturbs a value already in use.
         """
         if not self.access_token or not vin:
             return ""
@@ -954,10 +958,10 @@ class ZeekrClient:
                 candidate = derive_x_vin(vin, key, iv)
                 self.enc_vin = candidate
                 try:
-                    self.capabilities_new()
+                    if self.capabilities_new():   # non-empty => resolved to a car
+                        return candidate
                 except (ZeekrAuthError, ZeekrApiError):
                     continue
-                return candidate
             return ""
         finally:
             self.enc_vin = saved

--- a/custom_components/geely_connect/zeekr_client.py
+++ b/custom_components/geely_connect/zeekr_client.py
@@ -110,6 +110,34 @@ HF_APP_ID = "GEELY-APP-NEW"
 HF_SECRET = "eeec50cb855a4c69a12f297c0d27a07f"  # NativeSecretLib "GEELY_EM"
 HF_ACCEPT = "application/json;responseformat=3"
 
+# --- x-vin (X-VIN header) derivation -------------------------------------
+# The new gateway addresses a vehicle by an *encrypted* VIN in the `x-vin`
+# header. The app derives it locally from the ordinary VIN:
+#   VIN -> AES-128-CBC (PKCS#7 pad) -> standard Base64.
+# The AES material is per-app-build package data, not an account credential
+# or session token; it is already public (github.com/Wysie/zeekr_key_extractor
+# and PR #57). It differs by app build/region, and a WRONG pair yields a
+# valid-looking but wrong header that only fails at request time, so we never
+# trust a derived value blindly: `probe_x_vin` derives with each known pair
+# and keeps the one the gateway actually accepts, else falls back to the
+# owner-supplied `zeekr_enc_vin` option. Add a pair as new builds are captured.
+_X_VIN_MATERIAL: tuple[tuple[bytes, bytes, str], ...] = (
+    # (key, iv, note) -- 16-byte ASCII AES-128 key + 16-byte ASCII IV
+    (b"a01a6db985a2f5d4", b"ed446b8b8845013d", "PR #57"),
+    (b"2a25d6c112dcf841", b"53bd2ae715ff176f", "Geely Global EM (com.geely.global.em, AU/SEA)"),
+)
+
+
+def derive_x_vin(vin: str, key: bytes, iv: bytes) -> str:
+    """One app build's VIN -> x-vin transform (AES-128-CBC/PKCS7 -> Base64)."""
+    from cryptography.hazmat.primitives import padding
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    padder = padding.PKCS7(128).padder()
+    pt = padder.update(vin.encode("ascii")) + padder.finalize()
+    enc = Cipher(algorithms.AES(key), modes.CBC(iv)).encryptor()
+    return base64.b64encode(enc.update(pt) + enc.finalize()).decode("ascii")
+
 # Per-install device identity for HF requests: the app derives one per
 # device, so a shared static value would let the vendor correlate every HA
 # install as a single device. Regenerated per process; not part of any
@@ -907,6 +935,32 @@ class ZeekrClient:
                 if isinstance(val, list):
                     return [v for v in val if isinstance(v, dict)]
         return []
+
+    def probe_x_vin(self, vin: str) -> str:
+        """Derive the x-vin from the plain VIN and return the value the new
+        gateway accepts, or "" if none of the known app builds match.
+
+        Each candidate is verified with a read-only, x-vin-addressed call (the
+        capability catalogue): a wrong x-vin is rejected by the gateway and
+        raises, so only a value the gateway resolves to this vehicle is
+        returned. Restores the client's previous x-vin on the way out, so a
+        failed probe never disturbs a value already in use.
+        """
+        if not self.access_token or not vin:
+            return ""
+        saved = self.enc_vin
+        try:
+            for key, iv, _note in _X_VIN_MATERIAL:
+                candidate = derive_x_vin(vin, key, iv)
+                self.enc_vin = candidate
+                try:
+                    self.capabilities_new()
+                except (ZeekrAuthError, ZeekrApiError):
+                    continue
+                return candidate
+            return ""
+        finally:
+            self.enc_vin = saved
 
     def capabilities_new(self) -> list[dict]:
         """The new platform's capability catalogue for this vehicle.

--- a/tests/test_zeekr_config_flow.py
+++ b/tests/test_zeekr_config_flow.py
@@ -418,3 +418,31 @@ def test_reconfigure_choosing_legacy_goes_to_the_legacy_form():
     flow.hass.config_entries.async_get_entry = lambda eid: entry
     res = asyncio.run(flow.async_step_reconfigure({"platform": "legacy"}))
     assert res["type"] == "form" and res["step_id"] == "user", res
+
+
+class _DerivingClient(_FakeClient):
+    """A logged-in client whose app build's x-vin the gateway accepts."""
+    def probe_x_vin(self, vin):
+        return "DERIVED-XVIN=="
+
+
+def test_zeekr_login_auto_derives_and_stores_the_x_vin():
+    cf, flow = _flow()
+    cf._zeekr_login_password = lambda e, p, c: _DerivingClient()
+    asyncio.run(flow.async_step_user({"platform": "zeekr"}))
+    res = asyncio.run(flow.async_step_zeekr_login(_zeekr_login_input()))
+    assert res["type"] == "create_entry", res
+    assert res["data"]["zeekr_enc_vin"] == "DERIVED-XVIN==", (
+        "a verified derived x-vin must be stored so the car works without a "
+        "manual token")
+
+
+def test_zeekr_migration_stores_the_derived_x_vin():
+    cf, flow = _flow()
+    entry = _legacy_entry()
+    flow._reauth_entry = entry
+    cf._zeekr_login_password = lambda e, p, c: _DerivingClient()
+    asyncio.run(flow.async_step_user({"platform": "zeekr"}))
+    res = asyncio.run(flow.async_step_zeekr_login(_zeekr_login_input()))
+    assert res["type"] == "abort" and res["reason"] == "reauth_successful", res
+    assert entry.data["zeekr_enc_vin"] == "DERIVED-XVIN=="

--- a/tests/test_zeekr_x_vin.py
+++ b/tests/test_zeekr_x_vin.py
@@ -67,6 +67,18 @@ def test_probe_returns_empty_when_no_build_matches():
     assert client.enc_vin == "keep-me"
 
 
+def test_probe_rejects_an_empty_catalogue_even_without_a_raise():
+    """Acceptance is positive: a candidate the gateway answered with an empty
+    catalogue (a hypothetical HTTP 200 + no rows, no raise) must NOT be stored,
+    so a wrong x-vin can never be false-accepted."""
+    client = zc.ZeekrClient(email="a@b.c", password="")
+    client.access_token = "tok"
+    client.capabilities_new = lambda: []      # never raises, always empty
+    client.enc_vin = "keep-me"
+    assert client.probe_x_vin(FAKE_VIN) == ""
+    assert client.enc_vin == "keep-me"
+
+
 def test_probe_needs_a_session_and_a_vin():
     client = _client_with("x")
     client.access_token = None

--- a/tests/test_zeekr_x_vin.py
+++ b/tests/test_zeekr_x_vin.py
@@ -1,0 +1,75 @@
+"""x-vin derivation: VIN -> AES-128-CBC/PKCS7 -> Base64, per known app build,
+verified against the gateway before use.
+
+Vectors use an obviously fake VIN only; no real VIN, x-vin, key provenance
+beyond the public material, or captured request is in this file.
+"""
+from __future__ import annotations
+
+import base64
+
+from conftest import load
+
+zc = load("zeekr_client")
+
+FAKE_VIN = "TESTVIN0000000001"          # 17 chars, not a real VIN
+# Pins the two shipped (key, iv) pairs so a silent constant change is caught.
+_VECTORS = {
+    b"a01a6db985a2f5d4": "NC5s9vGCMCIqeBTHAf2obrtzAkYDBU8zWHPJPQ0/5NM=",
+    b"2a25d6c112dcf841": "vXhc1YYp6iF/RD27Bhn5RNwmARwFRTr9A1wiKclIukU=",
+}
+
+
+def test_derive_x_vin_matches_the_pinned_vectors():
+    for key, iv, _note in zc._X_VIN_MATERIAL:
+        assert zc.derive_x_vin(FAKE_VIN, key, iv) == _VECTORS[key], key
+
+
+def test_derive_x_vin_is_a_reversible_aes_cbc_pkcs7():
+    """Independent of any pinned vector: decrypting with the same material must
+    return the VIN, i.e. it really is AES-128-CBC with PKCS7 padding."""
+    from cryptography.hazmat.primitives import padding
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    for key, iv, _note in zc._X_VIN_MATERIAL:
+        ct = base64.b64decode(zc.derive_x_vin(FAKE_VIN, key, iv))
+        dec = Cipher(algorithms.AES(key), modes.CBC(iv)).decryptor()
+        padded = dec.update(ct) + dec.finalize()
+        unpad = padding.PKCS7(128).unpadder()
+        assert (unpad.update(padded) + unpad.finalize()).decode() == FAKE_VIN
+
+
+def _client_with(accepting_x_vin):
+    """A logged-in client whose capability call only succeeds for one x-vin."""
+    client = zc.ZeekrClient(email="a@b.c", password="")
+    client.access_token = "tok"
+    def fake_caps():
+        if client.enc_vin != accepting_x_vin:
+            raise zc.ZeekrApiError("HTTP 401: rejected x-vin")
+        return [{"functionCode": "x"}]
+    client.capabilities_new = fake_caps
+    return client
+
+
+def test_probe_returns_the_value_the_gateway_accepts():
+    key, iv, _ = zc._X_VIN_MATERIAL[-1]         # the AU/SEA build
+    accepted = zc.derive_x_vin(FAKE_VIN, key, iv)
+    client = _client_with(accepted)
+    client.enc_vin = "previous-value"
+    assert client.probe_x_vin(FAKE_VIN) == accepted
+    # the probe must not disturb whatever x-vin was already set
+    assert client.enc_vin == "previous-value"
+
+
+def test_probe_returns_empty_when_no_build_matches():
+    client = _client_with("something-no-build-produces")
+    client.enc_vin = "keep-me"
+    assert client.probe_x_vin(FAKE_VIN) == ""
+    assert client.enc_vin == "keep-me"
+
+
+def test_probe_needs_a_session_and_a_vin():
+    client = _client_with("x")
+    client.access_token = None
+    assert client.probe_x_vin(FAKE_VIN) == ""
+    client.access_token = "tok"
+    assert client.probe_x_vin("") == ""


### PR DESCRIPTION
New-platform vehicles need an `x-vin` header (an encrypted VIN). Today it's an advanced owner-supplied option (`zeekr_enc_vin`); this derives it **automatically** so a new-platform car works out of the box, while keeping the manual override.

Builds on @scottaki's **#57**, which found the mechanism: `VIN → AES-128-CBC/PKCS7 → Base64`. The difference here is **the material is per-app-build and a wrong key produces a valid-looking but wrong header that only fails at request time** — so this never trusts a derived value blindly.

### How it works
- `derive_x_vin(vin, key, iv)` + `_X_VIN_MATERIAL` — the known `(key, iv)` pairs.
- `probe_x_vin(vin)` — derives with each pair and **verifies** each with a read-only, x-vin-addressed call (the capability catalogue). The gateway rejects a wrong x-vin (raises), so only a value it actually resolves to the vehicle is returned; the client's previous x-vin is restored either way.
- `config_flow` stores **only a verified** value. The manual `zeekr_enc_vin` option still overrides; an existing manual value is preserved on reauth; and **if no known build matches, nothing is stored** — behaviour is exactly as before (manual fallback). A future key rotation therefore degrades gracefully instead of hard-breaking.

### Why not a single hard-coded key (re: #57)
I tested #57's bundled key/IV against a live AU/SEA car and it does **not** reproduce that car's real x-vin (commented on #57). Different builds/regions use different material (Wysie issue #10: keys are per-version, ECIES-encrypted in newer builds). Hence: a **list** of known builds + **verify-before-use**, so an unknown build never silently mis-derives.

### Known builds shipped
- the pair from #57;
- **Geely Global EM (AU/SEA, `com.geely.global.em`)** — recovered and **validated against a real AU vehicle** (derives that car's exact working x-vin). Add more as builds are captured.

The AES material is public app package data (github.com/Wysie/zeekr_key_extractor, #57), not an account credential or session token; `enc_vin` is already redacted from logs and diagnostics.

### Tests
Derive vectors (fake VIN only) + AES round-trip + probe (verify / fallback-to-empty / restore-on-exit), plus two config-flow cases (derive-and-store, migration-stores). Full suite green locally; `coverage --fail-under=100` passes (`custom_components/geely_connect` TOTAL 100%).