### PR TITLE
Cards: Windows open/close control, open indicator, and open %

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ dashboard, **Add card**, and search "Geely":
 
 | Card | What it is |
 |---|---|
-| **Geely Card** (`custom:geely-card`) | The full cockpit: range and battery up top, the EX5 silhouette that glows while charging and flags every opening, one-tap Lock / Unlock / Climate / Defrost / Vent / Trunk / Find / Sync, a full climate panel (temperature, rapid heat / cool, seat heating and cooling, fresh air, sunroof and shade), charging and schedule toggles with editable start / end times, links that navigate you to wherever the car is parked, then charging, tires, trip and service health - each block hides itself when the car doesn't report it |
+| **Geely Card** (`custom:geely-card`) | The full cockpit: range and battery up top, the EX5 silhouette that glows while charging and flags every opening, one-tap Lock / Unlock / Climate / Defrost / Vent / Trunk / Find / Sync, a full climate panel (temperature, rapid heat / cool, seat heating and cooling, fresh air, windows, sunroof and shade), charging and schedule toggles with editable start / end times, links that navigate you to wherever the car is parked, then charging, tires, trip and service health - each block hides itself when the car doesn't report it |
 | **Geely Card (top view)** (`custom:geely-card-top`) | The car from above: tire pressure beside each wheel, bold live status on every door, the hood, the sunroof and the trunk - with the same header, actions and climate panel. The driver's door follows your market automatically (right-hand-drive countries show it on the right; `rhd: true/false` in the card config overrides) |
 | **Geely Card (compact)** (`custom:geely-card-compact`) | The essentials in one tile: battery and cabin temperature in the header, range, status chips - and Lock, Unlock, rapid Heat / Cool, Defrost and Trunk |
 | **Geely Card (mini)** (`custom:geely-card-mini`) | A small square: range, battery and cabin temperature in the header, status, a lock button that follows the car (locked offers Unlock, unlocked offers Lock), and one-tap quick heat / quick cool |
@@ -342,8 +342,9 @@ The full and top-view cards carry a complete **Climate** section:
 - **Seat heating / Seat cooling** per front seat - each tap steps
   Off → Low → Medium → High → Off.
 - **Fresh air** (G-Clean), **Parking comfort**, **Wheel heat** (on cars that
-  have a heated steering wheel), and **Open / Close** for the sunroof and the
-  sunshade. Parking comfort never lights up, deliberately: the car does not
+  have a heated steering wheel), and **Open / Close** for the windows, the
+  sunroof and the sunshade - each pair lights while that opening is open.
+  Parking comfort never lights up, deliberately: the car does not
   report whether it is on - the field that looks like its flag reads 1 with the
   feature off - so the button toggles it without claiming a state.
 - Every block hides itself on a trim that lacks the entity - and there is no

--- a/custom_components/geely_connect/cover.py
+++ b/custom_components/geely_connect/cover.py
@@ -43,7 +43,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import GeelyControlError, redact
 from .const import DOMAIN, SERVICE_WINDOW
-from .helpers import walk as _walk, windows_open, schedule_refresh
+from .helpers import walk as _walk, windows_open, windows_position, schedule_refresh
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -152,3 +152,10 @@ class GeelyWindows(_BaseGeelyCover):
         # none of them is unknown rather than open.
         opened = windows_open(self.coordinator.data)
         return None if opened is None else not opened
+
+    @property
+    def current_cover_position(self) -> int | None:
+        # The car reports a per-corner winPos (0-100); expose the most-open
+        # corner so the % shows how far the windows are down - a vent crack
+        # reads ~8, not just "open". None when the car omits winPos entirely.
+        return windows_position(self.coordinator.data)

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -1790,10 +1790,16 @@
         const st = this._st(`cover.${suffix}`);
         if (!st) return "";
         const isOpen = st.state === "open" || st.state === "opening";
+        // A partly-open cover that reports a position (the windows do: a vent
+        // crack is ~8%) shows how far, so "cracked" reads differently from
+        // "fully down". Whole open/closed covers (sunroof, shade) show nothing.
+        const pos = st.attributes && st.attributes.current_position;
+        const pct = (isOpen && typeof pos === "number" && pos > 0 && pos < 100)
+          ? ` ${pos}%` : "";
         const openWord = this._t("action.open", "Open");
         const closeWord = this._t("action.close", "Close");
         return `<div class="cpair ${isOpen ? "on" : ""}">
-            ${icon(ic)}<span>${esc(label)}</span>
+            ${icon(ic)}<span>${esc(label)}${pct}</span>
             <button class="cmini" data-act="${openKey}" title="${esc(this._t("tooltip.cover_open", "Open {label}", { label }))}">${esc(openWord)}</button>
             <button class="cmini" data-act="${closeKey}" title="${esc(this._t("tooltip.cover_close", "Close {label}", { label }))}">${esc(closeWord)}</button>
           </div>`;

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -34,7 +34,7 @@
     "scheduled_charging", "charger_connection", "tire_front_right",
     "tire_front_left", "tire_rear_right", "door_rear_right", "charging_power",
     "seat_heat_passenger", "seat_vent_passenger", "seat_heat_driver",
-    "seat_vent_driver", "sunshade", "g_clean", "parking_comfort",
+    "seat_vent_driver", "sunshade", "all_windows", "g_clean", "parking_comfort",
     "steering_wheel_heat",
     "tire_rear_left", "door_rear_left", "combined_range", "charge_complete",
     "charge_voltage", "electric_range", "charge_current", "door_passenger",
@@ -209,6 +209,7 @@
       "label.shade": "Shade",
       "label.start": "Start",
       "label.sunroof": "Sunroof",
+      "label.windows": "Windows",
       "label.synced": "Synced {time}",
       "label.temp_in": "{temp}° in",
       "label.temp_out": "{temp}° out",
@@ -312,6 +313,7 @@
       "label.shade": "ม่านบังแดด",
       "label.start": "เริ่ม",
       "label.sunroof": "ซันรูฟ",
+      "label.windows": "หน้าต่าง",
       "label.synced": "ซิงก์แล้ว {time}",
       "label.temp_in": "{temp}° ภายใน",
       "label.temp_out": "{temp}° ภายนอก",
@@ -419,6 +421,7 @@
       "label.temp_in": "{temp}° interno",
       "label.temp_out": "{temp}° esterno",
       "label.wheel_heat": "Riscaldamento volante",
+      "label.windows": "Finestrini",
       "level.high": "Alto",
       "level.low": "Basso",
       "level.medium": "Medio",
@@ -809,6 +812,8 @@
            <path d="M8 10.5h8M9.5 6.9v3.6M14.5 6.9v3.6"/>`,
     shade: `<path d="M4 14.5c0-5 3.6-8.5 8-8.5s8 3.5 8 8.5"/>
             <path d="M6 12h12M8.5 12c0 2.5 1.5 4 3.5 4s3.5-1.5 3.5-4"/>`,
+    window: `<rect x="4" y="6.5" width="16" height="11" rx="1.5"/>
+             <path d="M12 6.5v11M4 12h16"/>`,
     fresh: `<path d="M5 9.5c2.5 0 2.5-2 5-2s2.5 2 5 2 2.5-2 5-2"/>
             <path d="M5 14c2.5 0 2.5-2 5-2s2.5 2 5 2 2.5-2 5-2"/>
             <path d="M5 18.5c2.5 0 2.5-2 5-2s2.5 2 5 2 2.5-2 5-2"/>`,
@@ -1613,6 +1618,8 @@
         case "sunroof_close": this._call("cover", "close_cover", "sunroof"); break;
         case "shade_open": this._call("cover", "open_cover", "sunshade"); break;
         case "shade_close": this._call("cover", "close_cover", "sunshade"); break;
+        case "windows_open": this._call("cover", "open_cover", "all_windows"); break;
+        case "windows_close": this._call("cover", "close_cover", "all_windows"); break;
         case "gclean": this._call("switch", "toggle", "g_clean"); break;
         case "pcomfort": this._call("switch", "toggle", "parking_comfort"); break;
         case "swheel": this._call("switch", "toggle", "steering_wheel_heat"); break;
@@ -1813,6 +1820,7 @@
        * light up correctly; the tooltip covers the ones that do not. */
       const sunroofWord = this._t("label.sunroof", "Sunroof");
       const shadeWord = this._t("label.shade", "Shade");
+      const windowsWord = this._t("label.windows", "Windows");
       const airRow = (gclean ? `<button class="cbtn ${gclean.state === "on" ? "on" : ""}"
             data-act="gclean" title="${esc(this._t("tooltip.fresh_air", "Fresh air (G-Clean)"))}">${icon("fresh")}<span>${esc(this._t("label.fresh_air", "Fresh air"))}</span></button>` : "") +
         (pcomfort ? `<button class="cbtn ${pcomfort.state === "on" ? "on" : ""}"
@@ -1821,7 +1829,8 @@
             style="--lvl:${swheel.state === "on" ? 1 : 0}"
             data-act="swheel" title="${esc(this._t("tooltip.wheel_heat", SWHEEL_HINT))}">${icon("steering")}<span>${esc(this._t("label.wheel_heat", "Wheel heat"))}</span></button>` : "") +
         cover("sunroof", "sunroof_open", "sunroof_close", sunroofWord, "roof") +
-        cover("sunshade", "shade_open", "shade_close", shadeWord, "shade");
+        cover("sunshade", "shade_open", "shade_close", shadeWord, "shade") +
+        cover("all_windows", "windows_open", "windows_close", windowsWord, "window");
       return `
         <hr class="hairline">
         <p class="micro">${icon("climate")} ${esc(this._t("action.climate", "Climate"))}</p>

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -951,6 +951,25 @@
       background: color-mix(in srgb, ${AMBER} 15%, transparent);
       font-weight: 600;
     }
+    /* A clickable chip whose lit fraction (--lvl 0..1) shows how far open the
+     * windows are - a vent crack lights a sliver, fully down lights it all. */
+    .chip.lvl {
+      color: ${ON_TEXT}; font-weight: 600; cursor: pointer;
+      border-color: color-mix(in srgb, ${ACCENT} 55%, transparent);
+      background: linear-gradient(to right,
+        color-mix(in srgb, ${ACCENT} 22%, transparent) calc(var(--lvl, 0) * 100%),
+        transparent calc(var(--lvl, 0) * 100%));
+    }
+    .chip.lvl:hover { border-color: color-mix(in srgb, ${ACCENT} 80%, transparent); }
+    .win-menu { background: var(--ha-card-background, var(--card-background-color, #1c1c1e));
+      color: var(--primary-text-color, #e6e6e6); border-radius: 16px; padding: 16px;
+      display: flex; flex-direction: column; gap: 10px; min-width: 220px;
+      box-shadow: 0 18px 50px -12px rgba(0,0,0,.6); }
+    .win-menu h4 { margin: 0 0 2px; font-size: 13px; font-weight: 600; }
+    .win-menu button { font: inherit; padding: 12px; border-radius: 12px; cursor: pointer;
+      border: 1px solid color-mix(in srgb, ${ACCENT} 45%, transparent);
+      background: color-mix(in srgb, ${ACCENT} 14%, transparent); color: ${ON_TEXT}; }
+    .win-menu button:hover { background: color-mix(in srgb, ${ACCENT} 26%, transparent); }
     .actions { display: flex; gap: 8px; justify-content: space-between; }
     .act {
       flex: 1; display: flex; flex-direction: column; align-items: center; gap: 5px;
@@ -1620,6 +1639,7 @@
         case "shade_close": this._call("cover", "close_cover", "sunshade"); break;
         case "windows_open": this._call("cover", "open_cover", "all_windows"); break;
         case "windows_close": this._call("cover", "close_cover", "all_windows"); break;
+        case "windows_menu": this._openWindowsMenu(); break;
         case "gclean": this._call("switch", "toggle", "g_clean"); break;
         case "pcomfort": this._call("switch", "toggle", "parking_comfort"); break;
         case "swheel": this._call("switch", "toggle", "steering_wheel_heat"); break;
@@ -1984,6 +2004,43 @@
       this._expandDialog.showModal();
     }
 
+    /* A small Open / Close menu for the compact card's windows chip. Appended
+     * to document.body (not the shadow root) for the same top-layer/centring
+     * reason as _openFullCard. Its buttons route through _onAction, which is
+     * already blocked while driving, so this only ever opens when parked. */
+    _openWindowsMenu() {
+      const dlg = document.createElement("dialog");
+      dlg.style.cssText = [
+        "position:fixed", "inset:0", "margin:auto", "border:none",
+        "padding:0", "background:transparent", "color:inherit",
+        "width:max-content", "max-width:92vw",
+      ].join(";");
+      _ensureExpandBackdropStyle();
+      const panel = document.createElement("div");
+      panel.className = "win-menu";
+      const title = document.createElement("h4");
+      title.textContent = this._t("label.windows", "Windows");
+      panel.appendChild(title);
+      const add = (label, act) => {
+        const b = document.createElement("button");
+        b.textContent = label;
+        b.addEventListener("click", () => { dlg.close(); this._onAction(act); });
+        panel.appendChild(b);
+      };
+      add(this._t("action.open", "Open"), "windows_open");
+      add(this._t("action.close", "Close"), "windows_close");
+      // The panel needs the card's theme tokens and its own class rules, so
+      // carry a copy of the card CSS into the dialog's own scope.
+      const style = document.createElement("style");
+      style.textContent = this.shadowRoot.querySelector("style")
+        ? this.shadowRoot.querySelector("style").textContent : "";
+      dlg.append(style, panel);
+      dlg.addEventListener("click", (ev) => { if (ev.target === dlg) dlg.close(); });
+      dlg.addEventListener("close", () => dlg.remove());
+      document.body.appendChild(dlg);
+      dlg.showModal();
+    }
+
     /* An unreachable image must fail quietly rather than leaving lamps hovering
      * over a broken-image glyph. Inline handlers are avoided because a strict
      * CSP would drop them silently. */
@@ -2196,6 +2253,14 @@
       const drivingWord = this._t("chip.driving", "Driving");
       const parkedWord = this._t("chip.parked", "Parked");
       const chargingWord = this._t("action.charging", "Charging");
+      const windowsWord = this._t("label.windows", "Windows");
+      const windowsCover = this._st("cover.all_windows");
+      const windowsOpen = windowsCover &&
+        (windowsCover.state === "open" || windowsCover.state === "opening");
+      const winPos = windowsCover && windowsCover.attributes
+        ? windowsCover.attributes.current_position : null;
+      const winFrac = typeof winPos === "number"
+        ? Math.max(0, Math.min(1, winPos / 100)) : 1;
       const chips = [
         // First, and only while it is true: the compact card falls back to a
         // "Parked" chip when nothing else applies, which on a moving car was the
@@ -2208,6 +2273,9 @@
         !s.charging && s.conn && s.conn.state === "Plugged in" && `<span class="chip">${esc(this._t("chip.plugged_in", "Plugged in"))}</span>`,
         climateOn && `<span class="chip on">${esc(this._t("chip.climate_on", "Climate on"))}</span>`,
         s.doorsOpen.length > 0 && `<span class="chip warn">${esc(this._t("chip.n_open", "{count} open", { count: s.doorsOpen.length }))}</span>`,
+        // Windows: only while open, the lit fraction shows how far, and a tap
+        // opens a small Open / Close menu (blocked while driving like any action).
+        windowsOpen && `<span class="chip lvl" style="--lvl:${winFrac}" data-act="windows_menu" role="button" tabindex="0" title="${esc(this._t("tooltip.windows_menu", "Open or close the windows"))}">${icon("window")} ${esc(windowsWord)}${typeof winPos === "number" ? ` ${winPos}%` : ""}</span>`,
       ].filter(Boolean).join("");
 
       this.shadowRoot.innerHTML = `<style>${BASE_CSS}

--- a/custom_components/geely_connect/helpers.py
+++ b/custom_components/geely_connect/helpers.py
@@ -242,6 +242,29 @@ def windows_open(data: Any) -> bool | None:
     return False if any_seen else None
 
 
+def windows_position(data: Any) -> int | None:
+    """How far open the windows are, 0-100, as the most-open corner.
+
+    The car reports a per-corner `winPos*` alongside `winStatus*`; the command
+    range is 0-100 (step 4), and a vent crack reads ~8. Returns the maximum so
+    the aggregate "All Windows" cover reads how open the most-open window is,
+    or None when the car publishes no `winPos*` field at all.
+    """
+    climate = walk(data or {}, _CLIMATE_PATH) or {}
+    best: int | None = None
+    for corner in WINDOW_CORNERS:
+        v = climate.get(f"winPos{corner}")
+        if v is None:
+            continue
+        try:
+            n = int(float(v))
+        except (TypeError, ValueError):
+            continue
+        n = max(0, min(100, n))
+        best = n if best is None else max(best, n)
+    return best
+
+
 def schedule_refresh(hass: HomeAssistant, coordinator, *delays: float,
                      after: Callable[[], None] | None = None) -> None:
     """Poll the car again a little after a command, without blocking the call.

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -99,7 +99,9 @@ window.mkHass = (opts) => {
   // exists, so a trim without one gets no row rather than a dead control.
   if (opts.covers) {
     const c = opts.covers;
-    if (c.windows) put(`cover.${P}_all_windows`, c.windows, { device_class: "window" });
+    if (c.windows) put(`cover.${P}_all_windows`, c.windows,
+        { device_class: "window",
+          ...(c.windowsPos != null ? { current_position: c.windowsPos } : {}) });
     if (c.sunroof) put(`cover.${P}_sunroof`, c.sunroof, { device_class: "shade" });
     if (c.sunshade) put(`cover.${P}_sunshade`, c.sunshade, { device_class: "shade" });
   }
@@ -1990,3 +1992,29 @@ def test_pressing_windows_open_calls_the_cover_service():
             return el._hass.serviceCalls;
         })()""", covers={"windows": "closed"})
     assert ["cover", "open_cover", {"entity_id": "cover.car_all_windows"}] in got, got
+
+
+def test_windows_show_their_open_percentage_when_partly_open():
+    """The car reports a per-window position (a vent crack ~8%), so a partly
+    open window reads e.g. "Windows 8%" rather than a bare "open"."""
+    got = _mount("geely-card", """
+            [...el.shadowRoot.querySelectorAll('.cpair')]
+              .find(p => p.querySelector('[data-act="windows_open"]'))
+              .querySelector('span').textContent.trim()
+        """, covers={"windows": "open", "windowsPos": 8})
+    assert got == "Windows 8%", got
+
+
+def test_windows_hide_the_percentage_when_fully_open_or_closed():
+    full = _mount("geely-card", """
+            [...el.shadowRoot.querySelectorAll('.cpair')]
+              .find(p => p.querySelector('[data-act="windows_open"]'))
+              .querySelector('span').textContent.trim()
+        """, covers={"windows": "open", "windowsPos": 100})
+    assert full == "Windows", full   # 100% -> just "Windows" (fully down)
+    closed = _mount("geely-card", """
+            [...el.shadowRoot.querySelectorAll('.cpair')]
+              .find(p => p.querySelector('[data-act="windows_open"]'))
+              .querySelector('span').textContent.trim()
+        """, covers={"windows": "closed", "windowsPos": 0})
+    assert closed == "Windows", closed

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -2018,3 +2018,38 @@ def test_windows_hide_the_percentage_when_fully_open_or_closed():
               .querySelector('span').textContent.trim()
         """, covers={"windows": "closed", "windowsPos": 0})
     assert closed == "Windows", closed
+
+
+# ------------------------------------- compact card: the windows chip + menu
+
+def test_compact_windows_chip_appears_only_when_open_with_a_proportional_fill():
+    got = _mount("geely-card-compact", """(() => {
+            const c = el.shadowRoot.querySelector('.chip.lvl[data-act="windows_open"], .chip.lvl[data-act="windows_menu"]');
+            return c ? { text: c.textContent.trim(), lvl: c.style.getPropertyValue('--lvl').trim() } : null;
+        })()""", covers={"windows": "open", "windowsPos": 8})
+    assert got is not None, "no windows chip while open"
+    assert "8%" in got["text"], got
+    assert got["lvl"] == "0.08", got            # 8% -> 0.08 of the chip lit
+
+
+def test_compact_windows_chip_absent_when_closed():
+    got = _mount("geely-card-compact", """
+            !!el.shadowRoot.querySelector('[data-act="windows_menu"]')
+        """, covers={"windows": "closed", "windowsPos": 0})
+    assert got is False, got
+
+
+def test_compact_windows_chip_opens_an_open_close_menu_that_acts():
+    got = _mount("geely-card-compact", """(() => {
+            document.querySelectorAll('dialog.win-menu, dialog .win-menu').forEach(d => {
+                const dlg = d.closest('dialog'); if (dlg) dlg.remove();
+            });
+            el.shadowRoot.querySelector('[data-act="windows_menu"]').click();
+            const menu = document.querySelector('.win-menu');
+            const labels = menu ? [...menu.querySelectorAll('button')].map(b => b.textContent.trim()) : [];
+            const open = menu && [...menu.querySelectorAll('button')].find(b => /open/i.test(b.textContent));
+            if (open) open.click();
+            return { labels, calls: el._hass.serviceCalls };
+        })()""", covers={"windows": "open", "windowsPos": 8})
+    assert got["labels"] == ["Open", "Close"], got
+    assert ["cover", "open_cover", {"entity_id": "cover.car_all_windows"}] in got["calls"], got

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -95,6 +95,14 @@ window.mkHass = (opts) => {
     if (seat.ventDriver !== null) put(`select.${P}_seat_vent_driver`, seat.ventDriver || "Off", { options: lvls });
     if (seat.ventPassenger !== null) put(`select.${P}_seat_vent_passenger`, seat.ventPassenger || "Off", { options: lvls });
   }
+  // Covers (sunroof / sunshade / all windows) render only when the entity
+  // exists, so a trim without one gets no row rather than a dead control.
+  if (opts.covers) {
+    const c = opts.covers;
+    if (c.windows) put(`cover.${P}_all_windows`, c.windows, { device_class: "window" });
+    if (c.sunroof) put(`cover.${P}_sunroof`, c.sunroof, { device_class: "shade" });
+    if (c.sunshade) put(`cover.${P}_sunshade`, c.sunshade, { device_class: "shade" });
+  }
   if (opts.noElectric) { delete S[`sensor.${P}_electric_range`]; }
   if (opts.at) {
     S[`device_tracker.${P}_location`] = { entity_id: `device_tracker.${P}_location`,
@@ -1937,3 +1945,48 @@ def test_every_shipped_language_covers_the_english_key_set():
                 f"{lang}.{key} uses {{plural}}, which is substituted with the "
                 f"English \"s\" - reword so the string works for any count: "
                 f"{text!r}")
+
+
+# --------------------------------------------- windows open/close + indicator
+
+def test_windows_cover_shows_open_close_and_lights_when_open():
+    """The RWS windows command shipped, but the card had no control for it.
+    The full card now carries a Windows Open/Close pair that lights when the
+    windows are open - the same cover row that already does sunroof/shade."""
+    got = _mount("geely-card", """(() => {
+            const pairs = [...el.shadowRoot.querySelectorAll('.cpair')];
+            const w = pairs.find(p => p.querySelector('[data-act="windows_open"]'));
+            if (!w) return { present: false };
+            return {
+                present: true,
+                on: w.classList.contains('on'),
+                acts: [...w.querySelectorAll('[data-act]')].map(b => b.dataset.act),
+            };
+        })()""", covers={"windows": "open"})
+    assert got["present"] is True, got
+    assert got["on"] is True, got                       # open -> the pair lights
+    assert got["acts"] == ["windows_open", "windows_close"], got
+
+
+def test_windows_cover_is_not_lit_when_closed():
+    got = _mount("geely-card", """(() => {
+            const p = [...el.shadowRoot.querySelectorAll('.cpair')]
+                .find(x => x.querySelector('[data-act="windows_open"]'));
+            return { on: p.classList.contains('on') };
+        })()""", covers={"windows": "closed"})
+    assert got["on"] is False, got
+
+
+def test_no_windows_control_without_the_cover_entity():
+    got = _mount("geely-card", """
+            !![...el.shadowRoot.querySelectorAll('[data-act="windows_open"]')].length
+        """)
+    assert got is False, got
+
+
+def test_pressing_windows_open_calls_the_cover_service():
+    got = _mount("geely-card", """(() => {
+            el.shadowRoot.querySelector('[data-act="windows_open"]').click();
+            return el._hass.serviceCalls;
+        })()""", covers={"windows": "closed"})
+    assert ["cover", "open_cover", {"entity_id": "cover.car_all_windows"}] in got, got

--- a/tests/test_platform_commands.py
+++ b/tests/test_platform_commands.py
@@ -582,6 +582,23 @@ def test_windows_cover_follows_the_four_corner_fields():
     assert entity.is_closed is None
 
 
+def test_windows_cover_reports_the_most_open_corner_as_its_position():
+    _need_ha()
+    # A vent crack reads ~8 on every corner; the aggregate reports the max.
+    _, entity = _make_cover("GeelyWindows", data=_climate_data(
+        winPosDriver=8, winPosPassenger=8, winPosDriverRear=8, winPosPassengerRear=8))
+    assert entity.current_cover_position == 8
+    # One window further down wins; junk and out-of-range are tolerated/clamped.
+    _, entity = _make_cover("GeelyWindows", data=_climate_data(
+        winPosDriver="8", winPosPassenger="60", winPosDriverRear="x", winPosPassengerRear="140"))
+    assert entity.current_cover_position == 100
+    # No winPos field at all -> unknown, not 0.
+    _, entity = _make_cover("GeelyWindows", data=_climate_data())
+    assert entity.current_cover_position is None
+    _, entity = _make_cover("GeelyWindows", data=None)
+    assert entity.current_cover_position is None
+
+
 # --------------------------------------------------------- device_tracker ---
 
 def _pos_data(**pos):


### PR DESCRIPTION
The RWS **windows** command shipped in #60 and `cover.py` exposes a `cover.<car>_all_windows` entity, but the cards had no way to drive it — and no indication of whether the windows are open, or how far. This adds all three.

### What it does
- **Full + top cards:** a **Windows** row with **Open / Close** buttons that **lights while the windows are open** — the same `cover()` helper that already renders sunroof and sunshade, driving the existing `cover.<car>_all_windows` entity. No new command path.
- **Open %:** when a window is partly down the row shows the percentage — "Windows 8%" distinguishes a vent crack from fully open. Sunroof/shade report no position and are unchanged.
- **Compact card:** a Windows **chip** that appears *only while the windows are open*, its lit fraction tracking how far (a vent crack lights a sliver); tapping it opens a small **Open / Close** menu. The menu routes through `_onAction` (already blocked while driving), so on a moving car the chip is a read-only indicator and only acts when parked.

### Changes
**`geely-card.js`** — a `window` icon; `all_windows` added to the watched-suffix list so the indicator updates live; `windows_open`/`windows_close`/`windows_menu` actions; the cover row's windows pair with the % readout; the compact chip + its Open/Close menu; `label.windows` in the **en** and **th** dictionaries (th: หน้าต่าง — happy to have a native speaker confirm).

**`helpers.py`** — `windows_position(data)`: the most-open corner's `winPos` (0–100), clamped, junk/missing tolerated, `None` when the car omits it entirely.

**`cover.py`** — `GeelyWindows.current_cover_position` returns that, so the entity carries the position and the card can render it.

### On `winPos` (raised in review)
Confirmed present on the **new EM/Zeekr platform**. From a live `climateStatus` on a real EX2 (windows shut):

```
winPosDriver = '0'    winStatusDriver        = '2'  (2 = closed)
winPosDriverRear = '0'    winStatusDriverRear    = '2'
winPosPassenger = '0'    winStatusPassenger     = '2'
winPosPassengerRear = '0'    winStatusPassengerRear = '2'
```

The fields exist and read `'0'` because the windows are closed; a vent crack reads ~8. The legacy-platform payload on #24 has `winStatus*` but no `winPos*`, so this is a new-platform field — and `windows_position` returns `None` (no percentage shown) when it's absent, so legacy cars are unaffected. The `0–100 step 4` in my earlier note was the *command* range; the status field above is the independent evidence.

### Tests
Browser tests: full-card control (renders Open/Close, lights when open, not lit when closed, absent without the entity, press calls the cover service), the % shown/hidden, and the compact chip (present-with-fill, absent, opens-menu-and-acts). Platform test: `GeelyWindows` reports the most-open corner as its position. Full suite green, `coverage --fail-under=100` passes.

### Note
Rebased onto current `main` (resolves the earlier conflict — an additive clash in `test_cards_in_a_browser.py` with the new language-coverage test; both kept). Description refreshed to match the full diff (the open-% commits `76fe0b8`/`30ea9bb` added the `cover.py`/`helpers.py` changes after the PR was first opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
