### PR TITLE
Compact card: opt-in charging countdown (ready-by + time left)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Everything else is optional:
 | `battery_bold:` | `true` | Set `false` to draw the battery-% headline in a regular weight instead of bold |
 | `charge_time_format:` | `min` | How **Time to full** reads while charging: `min` (e.g. `249 min`) or `hm` for hours + minutes (e.g. `4h 9m`) |
 | `show_parked:` | `false` | Compact card only. `true` adds a **Parked** chip next to Locked while the car is stationary, matching the full card's status |
+| `charging_countdown:` | `false` | Compact card only. `true` moves the live charging power up to a **status line under the title** (as the full card shows it) and turns the charging chip into a **ready-by time + countdown** (e.g. `Ready 10:22 · 2h 15m left`) that ticks down each minute |
 | `car_image:` | *none* | Path or URL to your own photo of the car (e.g. `/local/geely/mycar.png` for a file in `config/www/geely/`). It replaces the drawn car while keeping the live overlay - headlights, tail lights, charge port and the open-panel markers. Transparent PNG/WebP, side-on, front to the left works best |
 | `car_image_hotspots:` | *sensible defaults* | Fine-tune where the overlay lights sit on your image, as percentages, if a different crop needs it - e.g. `{headlight: [8, 46], taillight: [94, 37], port: [86, 40]}` |
 

--- a/custom_components/geely_connect/geely-card.js
+++ b/custom_components/geely_connect/geely-card.js
@@ -184,6 +184,7 @@
       "action.vent": "Vent",
       "boot.boot": "Boot",
       "boot.trunk": "Trunk",
+      "chip.charge_ready": "Ready {at} · {left} left",
       "chip.climate_on": "Climate on",
       "chip.driving": "Driving",
       "chip.locked": "Locked",
@@ -287,6 +288,7 @@
       "action.vent": "ระบายอากาศ",
       "boot.boot": "กระโปรงท้าย",
       "boot.trunk": "ท้ายรถ",
+      "chip.charge_ready": "พร้อม {at} · เหลือ {left}",
       "chip.climate_on": "แอร์เปิดอยู่",
       "chip.driving": "กำลังขับ",
       "chip.locked": "ล็อกแล้ว",
@@ -390,6 +392,7 @@
       "action.vent": "Ventilazione",
       "boot.boot": "Portellone",
       "boot.trunk": "Bagagliaio",
+      "chip.charge_ready": "Pronto {at} · {left} rimanenti",
       "chip.climate_on": "Clima acceso",
       "chip.driving": "In marcia",
       "chip.locked": "Bloccata",
@@ -1193,6 +1196,8 @@
       // A pending arm-timeout must not fire a render on a removed card.
       clearTimeout(this._armedTimer);
       this._armed = null;
+      // A charging countdown must not keep re-rendering a removed card.
+      this._ensureMinuteTick(false);
       // The expand dialog lives in document.body, so it will not be removed
       // with the card's own DOM - take it with us.
       if (this._expandDialog) {
@@ -1200,6 +1205,18 @@
         this._expandDialog.remove();
         this._expandDialog = null;
         this._expandCard = null;
+      }
+    }
+
+    // A once-a-minute self-render so a charging countdown ticks down between
+    // polls (the car reports new data only every few minutes). Idempotent: a
+    // render calls this each time and it keeps the single running timer.
+    _ensureMinuteTick(on) {
+      if (on && !this._minuteTick) {
+        this._minuteTick = setInterval(() => this._safeRender(), 60000);
+      } else if (!on && this._minuteTick) {
+        clearInterval(this._minuteTick);
+        this._minuteTick = null;
       }
     }
 
@@ -2143,7 +2160,7 @@
 
   class GeelyCardCompact extends GeelyCardBase {
     _watched() {
-      return ["sensor.battery", "sensor.electric_range", "sensor.charger_connection",
+      const w = ["sensor.battery", "sensor.electric_range", "sensor.charger_connection",
         // Watched because the head row prints it (#52). A value the card
         // draws but does not watch freezes on screen - the render is
         // skipped whenever the signature is unchanged.
@@ -2152,6 +2169,10 @@
         "binary_sensor.door_driver", "binary_sensor.door_passenger",
         "binary_sensor.door_rear_left", "binary_sensor.door_rear_right",
         "binary_sensor.trunk", "binary_sensor.hood", "binary_sensor.connected"];
+      // Only the opt-in countdown reads the finish time, so it is only watched
+      // when that option is on - default cards keep their existing signature.
+      if (this._config.charging_countdown) w.push("sensor.charge_complete");
+      return w;
     }
 
     getCardSize() { return 4; }
@@ -2181,6 +2202,33 @@
       const drivingWord = this._t("chip.driving", "Driving");
       const parkedWord = this._t("chip.parked", "Parked");
       const chargingWord = this._t("action.charging", "Charging");
+
+      // Opt-in charging countdown (`charging_countdown: true`): the live power
+      // moves up to a status line under the title (as the full card shows it),
+      // and the chip below becomes a "ready by + time left" readout that ticks
+      // down each minute. Off by default, so an unset card is unchanged.
+      const countdown = !!this._config.charging_countdown;
+      const chargeComplete = countdown ? this._st("sensor.charge_complete") : null;
+      const chargingLine = countdown && s.charging
+        ? this._t("status.charging_line", "Charging{power}",
+            { power: power != null ? " · " + power.toFixed(1) + " kW" : "" })
+        : "";
+      const readyChip = (() => {
+        if (!countdown || !s.charging) return null;
+        if (chargeComplete && OK(chargeComplete)) {
+          const d = new Date(chargeComplete.state);
+          if (!isNaN(d)) {
+            const at = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+            const mins = Math.max(0, Math.round((d.getTime() - Date.now()) / 60000));
+            const left = mins >= 60 ? `${Math.floor(mins / 60)}h ${mins % 60}m` : `${mins}m`;
+            return this._t("chip.charge_ready", "Ready {at} · {left} left", { at, left });
+          }
+        }
+        return chargingWord;
+      })();
+      // Tick the "time left" down each minute while a countdown is on screen.
+      this._ensureMinuteTick(!!(readyChip && chargeComplete && OK(chargeComplete)));
+
       const chips = [
         // First, and only while it is true: the compact card falls back to a
         // "Parked" chip when nothing else applies, which on a moving car was the
@@ -2189,7 +2237,7 @@
         showParked && !driving && `<span class="chip">${esc(parkedWord)}</span>`,
         s.locked && `<span class="chip ${s.locked.state === "locked" ? "" : "warn"}">
             ${esc(s.locked.state === "locked" ? this._t("chip.locked", "Locked") : this._t("chip.unlocked", "Unlocked"))}</span>`,
-        s.charging && `<span class="chip on">${iconFilled("bolt")} ${power != null ? power.toFixed(1) + " kW" : esc(chargingWord)}</span>`,
+        s.charging && `<span class="chip on">${iconFilled("bolt")} ${countdown ? esc(readyChip) : (power != null ? power.toFixed(1) + " kW" : esc(chargingWord))}</span>`,
         !s.charging && s.conn && s.conn.state === "Plugged in" && `<span class="chip">${esc(this._t("chip.plugged_in", "Plugged in"))}</span>`,
         climateOn && `<span class="chip on">${esc(this._t("chip.climate_on", "Climate on"))}</span>`,
         s.doorsOpen.length > 0 && `<span class="chip warn">${esc(this._t("chip.n_open", "{count} open", { count: s.doorsOpen.length }))}</span>`,
@@ -2200,6 +2248,8 @@
         .title { font-size:13px; font-weight:600; letter-spacing:.02em; display:flex; align-items:center; gap:7px; }
         .dot { width:6px; height:6px; border-radius:50%; background:${ACCENT}; }
         .dot.off { background:${AMBER}; }
+        .status { font-size:12px; color: var(--secondary-text-color); margin-top:3px; }
+        .status.charging { color:${ACCENT}; font-weight:600; }
         .hero { display:flex; align-items:center; gap:14px; margin:8px 0 2px; }
         .hero .n { font-size:44px; }
         .hero .u { font-size:13px; color: var(--secondary-text-color); margin-left:3px; }
@@ -2218,6 +2268,7 @@
               (battSize || inTemp == null) ? "" : this._t("label.temp_in", "{temp}° in", { temp: Math.round(inTemp) }),
             ].filter(Boolean).join(" · ")}</span>
           </div>
+          ${chargingLine ? `<div class="status charging">${esc(chargingLine)}</div>` : ""}
           <div class="hero">
             <div>
               ${battSize ? `<div class="battpct num" style="font-size:${battSize}px;font-weight:${battBold ? 700 : 400}">${batt}%${inTemp == null ? "" : ` · ${Math.round(inTemp)}°`}</div>` : ""}

--- a/tests/test_cards_in_a_browser.py
+++ b/tests/test_cards_in_a_browser.py
@@ -819,6 +819,97 @@ def test_the_charging_banner_fallback_still_shows_power():
         assert "6.83 kW" in text, (tag, text)
 
 
+# ------------------------ opt-in compact charging countdown (charging_countdown)
+
+_COMPACT_COUNTDOWN_SCRIPT = r"""(arg) => {
+    const el = document.createElement("geely-card-compact");
+    document.body.appendChild(el);
+    el.setConfig(arg.cfg);
+    const hass = window.mkHass({});
+    hass.states["sensor.car_charging_power"] = {
+        entity_id: "sensor.car_charging_power", state: arg.power,
+        attributes: { unit_of_measurement: "kW", device_class: "power" } };
+    if (arg.completeMins !== null) {
+        const iso = new Date(Date.now() + arg.completeMins * 60000).toISOString();
+        hass.states["sensor.car_charge_complete"] = {
+            entity_id: "sensor.car_charge_complete", state: iso,
+            attributes: { device_class: "timestamp" } };
+    }
+    el.hass = hass;
+    const status = el.shadowRoot.querySelector(".status.charging");
+    const chip = [...el.shadowRoot.querySelectorAll(".chip")]
+        .find(c => /kW|Ready|Charging/.test(c.textContent));
+    const out = {
+        status: status ? status.textContent.replace(/\s+/g, " ").trim() : null,
+        chip: chip ? chip.textContent.replace(/\s+/g, " ").trim() : null,
+        tick: !!el._minuteTick,
+    };
+    el.remove();   // disconnectedCallback clears the tick timer
+    return out;
+}"""
+
+
+def test_compact_charging_countdown_moves_power_up_and_shows_ready_and_left():
+    """With `charging_countdown: true` the live power becomes a status line under
+    the title (like the full card) and the chip becomes a ready-by + time-left
+    readout."""
+    got = _evaluate(_COMPACT_COUNTDOWN_SCRIPT,
+                    arg={"cfg": {"charging_countdown": True},
+                         "power": "1.7", "completeMins": 135})
+    assert got["status"] and "1.7 kW" in got["status"], got
+    assert got["chip"] and "Ready" in got["chip"] and "left" in got["chip"], got
+    assert "kW" not in got["chip"], got          # power moved to the status line
+    assert got["tick"] is True, got              # a live countdown is ticking
+
+
+def test_compact_charging_default_keeps_the_kw_chip_and_no_top_line():
+    """Unset (the default), the card is unchanged: the kW chip stays and no
+    charging status line appears, so existing users see no difference."""
+    got = _evaluate(_COMPACT_COUNTDOWN_SCRIPT,
+                    arg={"cfg": {}, "power": "1.7", "completeMins": 135})
+    assert got["status"] is None, got
+    assert got["chip"] and "1.7 kW" in got["chip"], got
+    assert "Ready" not in (got["chip"] or ""), got
+    assert got["tick"] is False, got
+
+
+def test_compact_charging_countdown_falls_back_without_a_finish_time():
+    """Opted in and charging but the car has not reported a finish time yet: the
+    chip reads plainly 'Charging' and nothing ticks - a countdown needs a target."""
+    got = _evaluate(_COMPACT_COUNTDOWN_SCRIPT,
+                    arg={"cfg": {"charging_countdown": True},
+                         "power": "1.7", "completeMins": None})
+    assert got["status"] and "1.7 kW" in got["status"], got
+    assert got["chip"] and "Charging" in got["chip"], got
+    assert "Ready" not in got["chip"], got
+    assert got["tick"] is False, got
+
+
+def test_compact_charging_countdown_stops_ticking_when_charging_ends():
+    """The once-a-minute self-render is armed only while a countdown is shown and
+    cleared the moment charging stops, so a parked car is not re-rendering
+    forever."""
+    got = _evaluate(r"""() => {
+        const el = document.createElement("geely-card-compact");
+        document.body.appendChild(el);
+        el.setConfig({ charging_countdown: true });
+        const on = window.mkHass({});
+        on.states["sensor.car_charging_power"] = { entity_id: "sensor.car_charging_power",
+            state: "1.7", attributes: { unit_of_measurement: "kW", device_class: "power" } };
+        on.states["sensor.car_charge_complete"] = { entity_id: "sensor.car_charge_complete",
+            state: new Date(Date.now() + 3600000).toISOString(),
+            attributes: { device_class: "timestamp" } };
+        el.hass = on;
+        const during = !!el._minuteTick;
+        el.hass = window.mkHass({});   // no charging_power -> not charging
+        const after = !!el._minuteTick;
+        el.remove();
+        return { during, after };
+    }""")
+    assert got["during"] is True, got
+    assert got["after"] is False, got
+
+
 # ------------------------------------------- #29: the climate row on a phone
 
 _ROWS_PROBE = """(() => {


### PR DESCRIPTION
Adds an opt-in compact-card option that reworks how a charging session reads, for owners who want the finish time and remaining time at a glance rather than just the kW.

### What it does (when enabled)
- The live **power moves up to a status line under the title** — `Charging · 1.7 kW` — the same treatment the full card already gives it.
- The charging **chip becomes a countdown**: `Ready 10:22 · 2h 15m left`, derived from `charge_complete`.
- It **ticks down every minute** so the "time left" stays current between polls (the car only reports new data every few minutes).

### Opt-in — default is unchanged
New compact-card config option **`charging_countdown:` (default `false`)**. Unset, the card behaves exactly as today (the `⚡ 1.7 kW` chip, no status line), so existing users see no difference. `charge_complete` is only added to the watched set when the option is on, so a default card keeps its render signature.

```yaml
type: custom:geely-card-compact
prefix: my_geely_ex5
charging_countdown: true
```

### Implementation notes
- The minute tick is an idempotent timer on `GeelyCardBase` (`_ensureMinuteTick`): a render arms it only while a countdown is on screen and clears it the moment charging stops; `disconnectedCallback` clears it too, so a removed or parked card never keeps re-rendering.
- Countdown from `charge_complete` (absolute timestamp), formatted with the card's existing `toLocaleTimeString` style; the `h m` remaining matches the existing "Time to full" `hm` format. Falls back to a plain `Charging` chip (and no tick) when the car hasn't reported a finish time yet.
- New translation key `chip.charge_ready` in **en/th/it**; the status line reuses the existing `status.charging_line`.

### Tests
Four browser tests: opt-in shows the status line + ready/left chip and arms the tick; default keeps the kW chip and no status line; no-finish-time falls back to `Charging` with no tick; the tick is cleared when charging ends. Full browser suite green (102), language-coverage test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)