### PR TITLE
Add DC-only charge current and voltage sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ polished setup on top.
 ## ✨ Highlights
 
 - 🔒 **Security-first** - verified TLS plus public-key pinning.
-- 📊 **Everything enabled** - all 84 entities are on from the start (97 on a
+- 📊 **Everything enabled** - all 86 entities are on from the start (99 on a
   hybrid), no duplicates, nothing to switch on by hand.
 - 🧮 **Computed extras** - charging power, charge completion time, range at full
   charge and efficiency, none of which the car reports itself.
@@ -1118,7 +1118,7 @@ enabling. Everything the car reports, plus the computed extras above.
 
 The main thing that varies by car is propulsion: the thirteen fuel and engine
 entities are created only for a car with a tank, so a battery-electric EX5 gets
-84 entities and a PHEV gets 97. That's a decision made once at startup from your
+86 entities and a PHEV gets 99. That's a decision made once at startup from your
 account's `powerType` plus the car's own telemetry - there is no option to set.
 
 Two more - `Charging (reported)` and `Plugged In (reported)` - are built only for

--- a/custom_components/geely_connect/sensor.py
+++ b/custom_components/geely_connect/sensor.py
@@ -556,6 +556,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, add_entitie
            GeelyChargePowerSensor(coordinator, vin, device_name),
            GeelyChargeCurrentSensor(coordinator, vin, device_name),
            GeelyChargeVoltageSensor(coordinator, vin, device_name),
+           # DC-only views of a fast charge - the pile's current and its own
+           # output voltage - blank on AC and idle, so a dashboard can show a
+           # fast charge on its own without the AC/DC entities' idle noise.
+           GeelyDCChargeCurrentSensor(coordinator, vin, device_name),
+           GeelyDCChargeVoltageSensor(coordinator, vin, device_name),
            # The same DC pair, read for what it is rather than as a charge:
            # the pack's own power flow, which is what the car's dashboard
            # shows while driving. Signed, so one entity covers both
@@ -1223,6 +1228,19 @@ def _charge_leg(data: dict) -> tuple[float, float, bool] | None:
     return None
 
 
+def _dc_charging(data: dict) -> bool:
+    """True only while a real DC (fast-charge) session is delivering power.
+
+    Reuses the leg election above rather than re-deriving it: the DC-specific
+    sensors then light up on exactly the sessions Charging Power calls DC, and
+    stay `None` the rest of the time - which matters because the DC fields read
+    stale numbers when idle (a car parked or *driving* still reports a
+    `dcChargePileUAct` from its last fast charge). A gap beats a stale reading.
+    """
+    leg = _charge_leg(data or {})
+    return leg is not None and leg[2] is False and (leg[0] > 0 or leg[1] > 0)
+
+
 # Where a single-phase supply stops and a three-phase one begins. Mains are
 # 100-250 V single-phase; three-phase is 380-415 V line-to-line, and 400 V is
 # what an EX5 reports on one (#36).
@@ -1345,6 +1363,78 @@ class GeelyChargeVoltageSensor(CoordinatorEntity, _AutoPrecision):
     def native_value(self):
         leg = _charge_leg(self.coordinator.data or {})
         return None if leg is None else round(leg[0], 1)
+
+
+class GeelyDCChargeCurrentSensor(CoordinatorEntity, _AutoPrecision):
+    """Amps flowing in during a DC fast charge - `dcChargeIAct`, as a magnitude.
+
+    The AC/DC "Charge Current" entity already shows this while a DC session is
+    live; this one is the DC-only view, blank on AC and idle, so a dashboard can
+    show the fast-charge current on its own. Gated on the same DC verdict Charging
+    Power uses, so it never publishes the stale idle value the field carries.
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.CURRENT
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:current-dc"
+
+    def __init__(self, coordinator, vin: str, device_name: str) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"geely_{vin}_dc_charge_current"
+        self._attr_name = "DC Charge Current"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)}, manufacturer="Geely", name=device_name)
+
+    @property
+    def native_value(self):
+        # Read the magnitude off the elected leg rather than the raw field: the
+        # leg is only DC when dcChargeIAct already parsed, so there is no second
+        # failure mode to guard here.
+        leg = _charge_leg(self.coordinator.data or {})
+        if leg is None or leg[2] is not False or (leg[0] <= 0 and leg[1] <= 0):
+            return None
+        return round(leg[1], 1)
+
+
+class GeelyDCChargeVoltageSensor(CoordinatorEntity, _AutoPrecision):
+    """The DC charger's own output voltage - `dcChargePileUAct`.
+
+    Deliberately the *pile* (charger) voltage, not `dcChargeUAct`: that one is
+    the pack, which the AC/DC Charge Voltage entity already reports and which a
+    car can send mis-scaled (1586 V, #17). The pile field is what the fast
+    charger says it is delivering. Same DC gate and the same plausibility window,
+    so an absent or nonsensical reading is a gap, not a wrong number.
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.VOLTAGE
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:current-dc"
+
+    def __init__(self, coordinator, vin: str, device_name: str) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"geely_{vin}_dc_charge_voltage"
+        self._attr_name = "DC Charge Voltage"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)}, manufacturer="Geely", name=device_name)
+
+    @property
+    def native_value(self):
+        data = self.coordinator.data or {}
+        if not _dc_charging(data):
+            return None
+        try:
+            volts = float(_walk(data, (*_EV, "dcChargePileUAct")))
+        except (TypeError, ValueError):
+            return None
+        if not _PACK_VOLTS_MIN <= volts <= _PACK_VOLTS_MAX:
+            return None
+        return round(volts, 1)
 
 
 # The window a real traction pack's voltage can occupy. Below is a reading

--- a/tests/test_charge_power.py
+++ b/tests/test_charge_power.py
@@ -549,3 +549,50 @@ def test_a_negative_ac_current_is_never_published_as_a_charge_current():
     del ev["dcChargeUAct"], ev["dcChargeIAct"]
     amps = _make("GeelyChargeCurrentSensor", data).native_value
     assert amps is None or amps >= 0, amps
+
+
+# ------------------------------------------- DC-only current / voltage views ---
+
+def test_dc_sensors_show_the_pile_readings_during_a_dc_session():
+    """A live DC fast charge: the DC Charge Current is the magnitude of
+    dcChargeIAct, and the DC Charge Voltage is the pile's own output
+    (dcChargePileUAct), not the pack's dcChargeUAct."""
+    data = _charging(dcDcConnectStatus="3", dcChargeUAct="400.0",
+                     dcChargeIAct="-125.0", dcChargePileUAct="398.5")
+    assert _make("GeelyDCChargeCurrentSensor", data).native_value == 125.0
+    assert _make("GeelyDCChargeVoltageSensor", data).native_value == 398.5
+
+
+def test_dc_sensors_are_blank_when_idle_even_with_stale_pile_values():
+    """The DC fields keep their last-session numbers when parked (or driving),
+    so the sensors must read None off a session, not publish 396 V forever."""
+    data = _status(dcChargePileUAct="396.0", dcChargeIAct="7.6")
+    assert _make("GeelyDCChargeCurrentSensor", data).native_value is None
+    assert _make("GeelyDCChargeVoltageSensor", data).native_value is None
+
+
+def test_dc_sensors_stay_blank_through_an_ac_session():
+    """An AC wallbox is charging and the DC pile field still carries a stale
+    reading - the DC-only entities must not leak it into an AC charge."""
+    data = _charging(chargeUAct="240.0", chargeIAct="30.0",
+                     dcChargePileUAct="396.0", dcChargeIAct="7.6")
+    assert _make("GeelyDCChargeCurrentSensor", data).native_value is None
+    assert _make("GeelyDCChargeVoltageSensor", data).native_value is None
+
+
+def test_dc_voltage_rejects_an_implausible_pile_reading():
+    """The same plausibility wall Pack Power uses: a DC session whose pile
+    voltage is nonsense reads None, while the current still reports."""
+    data = _charging(dcDcConnectStatus="3", dcChargeUAct="400.0",
+                     dcChargeIAct="-125.0", dcChargePileUAct="1586.0")
+    assert _make("GeelyDCChargeVoltageSensor", data).native_value is None
+    assert _make("GeelyDCChargeCurrentSensor", data).native_value == 125.0
+
+
+def test_dc_voltage_is_none_when_the_pile_field_is_absent():
+    """A DC session the car reports without a pile voltage: the current still
+    reports off the pack pair, but the voltage has nothing to show."""
+    data = _charging(dcDcConnectStatus="3", dcChargeUAct="400.0",
+                     dcChargeIAct="-125.0")   # no dcChargePileUAct
+    assert _make("GeelyDCChargeVoltageSensor", data).native_value is None
+    assert _make("GeelyDCChargeCurrentSensor", data).native_value == 125.0

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -169,6 +169,7 @@ def test_an_entry_with_no_verdict_at_all_behaves_like_a_bev():
 _CHARGING_KEYS = frozenset({
     "charger_connected", "time_to_full_min", "charge_complete",
     "charge_power", "charge_current", "charge_voltage",
+    "dc_charge_current", "dc_charge_voltage",
     "bs_charger_plugged_in", "sw_charging", "sw_scheduled_charging",
     "time_scheduled_charging_start", "time_scheduled_charging_end",
 })


### PR DESCRIPTION
Two diagnostic sensors that surface a DC fast charge on its own: **DC Charge Current** and **DC Charge Voltage**.

### Why
The existing **Charge Current / Voltage** entities already switch to the DC pair via `_charge_leg` during a DC session, but the voltage they show is the *pack* (`dcChargeUAct`) — the field a car can send mis-scaled (1586 V, #17). The car also reports `dcChargePileUAct`, the **charger's own output voltage** (e.g. 396 V), which nothing surfaced. These two entities give a clean DC-only view — blank on AC and idle — so a dashboard can show a fast charge without the AC/DC entities' idle noise.

### What
- **DC Charge Current** ← magnitude of `dcChargeIAct`, read off the elected leg.
- **DC Charge Voltage** ← `dcChargePileUAct` (the pile/charger voltage), with the same pack-voltage plausibility window Pack Power uses as a backstop.

### The care that went in
- **Gated on an active DC session** via a shared `_dc_charging(data)` helper that reuses the vetted `_charge_leg` election — so the sensors light up on exactly the sessions Charging Power calls DC. This matters because the DC fields read **stale** when idle: a parked (or *driving*) car still reports a `dcChargePileUAct` from its last fast charge. A gap beats a stale reading.
- The current reads its magnitude off the leg (which is only DC once `dcChargeIAct` has parsed), so there's no second failure mode to guard. The voltage rejects an absent or out-of-window pile reading as `None`.
- Behind the same propulsion `charges` gate as the other charge entities, and added to the charging-entity gate test so a socketless car still gets none.

### Notes / testing
- Five tests: a live DC session (current = magnitude, voltage = pile), idle with stale fields (both blank), an AC session carrying a stale pile reading (both blank), an implausible pile voltage (voltage blank, current still reports), and an absent pile field (voltage blank).
- README entity counts updated 84/97 → 86/99 (the documented-counts test enforces these).
- `winPos`-style honesty: confirmed the fields exist and are populated on a real new-EM-platform EX2; the exact readings *during* a DC session are inferred from the integration's existing #10 DC log, since I have no DC session of my own to capture. Fails safe (`None`) if a real session's fields differ.
- Full `charge_power` and `entities` suites green; new lines are 100% covered. Running live on my own car.

🤖 Generated with [Claude Code](https://claude.com/claude-code)